### PR TITLE
feat: 中文本地化 - UI 全量汉化

### DIFF
--- a/ClaudeIsland/Core/SoundManager.swift
+++ b/ClaudeIsland/Core/SoundManager.swift
@@ -26,14 +26,14 @@ enum SoundEvent: String, CaseIterable {
     /// Human-readable label for display in settings UI
     var displayName: String {
         switch self {
-        case .sessionStart: return "Session Start"
-        case .processingBegins: return "Processing Begins"
-        case .needsApproval: return "Needs Approval"
-        case .approvalGranted: return "Approval Granted"
-        case .approvalDenied: return "Approval Denied"
-        case .sessionComplete: return "Session Complete"
-        case .error: return "Error"
-        case .compacting: return "Context Compacting"
+        case .sessionStart: return "会话开始"
+        case .processingBegins: return "开始处理"
+        case .needsApproval: return "需要审批"
+        case .approvalGranted: return "已批准"
+        case .approvalDenied: return "已拒绝"
+        case .sessionComplete: return "会话完成"
+        case .error: return "错误"
+        case .compacting: return "上下文压缩"
         }
     }
 

--- a/ClaudeIsland/UI/Components/ScreenPickerRow.swift
+++ b/ClaudeIsland/UI/Components/ScreenPickerRow.swift
@@ -33,7 +33,7 @@ struct ScreenPickerRow: View {
                         .foregroundColor(textColor)
                         .frame(width: 16)
 
-                    Text("Screen")
+                    Text("屏幕")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(textColor)
 
@@ -63,8 +63,8 @@ struct ScreenPickerRow: View {
                 VStack(spacing: 2) {
                     // Automatic option
                     ScreenOptionRow(
-                        label: "Automatic",
-                        sublabel: "Built-in or Main",
+                        label: "自动",
+                        sublabel: "内置或主屏幕",
                         isSelected: screenSelector.selectionMode == .automatic
                     ) {
                         screenSelector.selectAutomatic()
@@ -95,12 +95,12 @@ struct ScreenPickerRow: View {
     private var currentSelectionLabel: String {
         switch screenSelector.selectionMode {
         case .automatic:
-            return "Auto"
+            return "自动"
         case .specificScreen:
             if let screen = screenSelector.selectedScreen {
                 return screen.localizedName
             }
-            return "Auto"
+            return "自动"
         }
     }
 
@@ -111,10 +111,10 @@ struct ScreenPickerRow: View {
     private func screenSublabel(for screen: NSScreen) -> String? {
         var parts: [String] = []
         if screen.isBuiltinDisplay {
-            parts.append("Built-in")
+            parts.append("内置")
         }
         if screen == NSScreen.main {
-            parts.append("Main")
+            parts.append("主屏幕")
         }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }

--- a/ClaudeIsland/UI/Components/SoundPickerRow.swift
+++ b/ClaudeIsland/UI/Components/SoundPickerRow.swift
@@ -35,7 +35,7 @@ struct SoundPickerRow: View {
                         .foregroundColor(textColor)
                         .frame(width: 16)
 
-                    Text("Notification Sound")
+                    Text("通知声音")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(textColor)
 

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -233,7 +233,7 @@ struct ChatView: View {
             ProgressView()
                 .progressViewStyle(CircularProgressViewStyle(tint: .white.opacity(0.4)))
                 .scaleEffect(0.8)
-            Text("Loading messages...")
+            Text("加载消息中...")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white.opacity(0.4))
         }
@@ -247,7 +247,7 @@ struct ChatView: View {
             Image(systemName: "bubble.left.and.bubble.right")
                 .font(.system(size: 24))
                 .foregroundColor(.white.opacity(0.2))
-            Text("No messages yet")
+            Text("暂无消息")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white.opacity(0.4))
         }
@@ -349,7 +349,7 @@ struct ChatView: View {
                 HStack(spacing: 8) {
                     Image(systemName: "terminal")
                         .font(.system(size: 14, weight: .medium))
-                    Text("Go to Terminal")
+                    Text("前往终端")
                         .font(.system(size: 13, weight: .medium))
                 }
                 .foregroundColor(.white)
@@ -554,7 +554,7 @@ struct AssistantMessageView: View {
 // MARK: - Processing Indicator
 
 struct ProcessingIndicatorView: View {
-    private let baseTexts = ["Processing", "Working"]
+    private let baseTexts = ["处理中", "工作中"]
     private let color = Color(red: 0.85, green: 0.47, blue: 0.34) // Claude orange
     private let baseText: String
 
@@ -667,7 +667,7 @@ struct ToolCallView: View {
                     .fixedSize()
 
                 if tool.name == "Task" && !tool.subagentTools.isEmpty {
-                    let taskDesc = tool.input["description"] ?? "Running agent..."
+                    let taskDesc = tool.input["description"] ?? "运行代理中..."
                     Text("\(taskDesc) (\(tool.subagentTools.count) tools)")
                         .font(.system(size: 11))
                         .foregroundColor(textColor.opacity(0.7))
@@ -675,7 +675,7 @@ struct ToolCallView: View {
                         .truncationMode(.tail)
                 } else if tool.name == "AgentOutputTool", let desc = agentDescription {
                     let blocking = tool.input["block"] == "true"
-                    Text(blocking ? "Waiting: \(desc)" : desc)
+                    Text(blocking ? "等待中: \(desc)" : desc)
                         .font(.system(size: 11))
                         .foregroundColor(textColor.opacity(0.7))
                         .lineLimit(1)
@@ -779,7 +779,7 @@ struct SubagentToolsList: View {
         VStack(alignment: .leading, spacing: 2) {
             // Show count of older hidden tools at top
             if hiddenCount > 0 {
-                Text("+\(hiddenCount) more tool uses")
+                Text("还有 \(hiddenCount) 个工具调用")
                     .font(.system(size: 10))
                     .foregroundColor(.white.opacity(0.4))
             }
@@ -809,7 +809,7 @@ struct SubagentToolRow: View {
     /// Get status text using the same logic as regular tools
     private var statusText: String {
         if tool.status == .interrupted {
-            return "Interrupted"
+            return "已中断"
         } else if tool.status == .running {
             return ToolStatusDisplay.running(for: tool.name, input: tool.input).text
         } else {
@@ -863,7 +863,7 @@ struct SubagentToolsSummary: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Subagent used \(tools.count) tools:")
+            Text("子代理使用了 \(tools.count) 个工具：")
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(.white.opacity(0.5))
 
@@ -942,7 +942,7 @@ struct ThinkingView: View {
 struct InterruptedMessageView: View {
     var body: some View {
         HStack {
-            Text("Interrupted")
+            Text("已中断")
                 .font(.system(size: 13))
                 .foregroundColor(.red)
             Spacer()
@@ -967,7 +967,7 @@ struct ChatInteractivePromptBar: View {
                 Text(MCPToolFormatter.formatToolName("AskUserQuestion"))
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
                     .foregroundColor(TerminalColors.amber)
-                Text("Claude Code needs your input")
+                Text("Claude Code 需要你的输入")
                     .font(.system(size: 11))
                     .foregroundColor(.white.opacity(0.5))
                     .lineLimit(1)
@@ -984,7 +984,7 @@ struct ChatInteractivePromptBar: View {
                 HStack(spacing: 4) {
                     Image(systemName: "terminal")
                         .font(.system(size: 11, weight: .medium))
-                    Text("Terminal")
+                    Text("终端")
                         .font(.system(size: 13, weight: .medium))
                 }
                 .foregroundColor(.black)
@@ -1090,7 +1090,7 @@ struct ChatApprovalBar: View {
                 Circle()
                     .fill(Color(red: 1.0, green: 0.6, blue: 0.0))
                     .frame(width: 8, height: 8)
-                Text("Permission Request")
+                Text("权限请求")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(Color(red: 1.0, green: 0.7, blue: 0.2))
             }
@@ -1162,7 +1162,7 @@ struct ChatApprovalBar: View {
                     onDeny()
                 } label: {
                     HStack(spacing: 4) {
-                        Text("Deny")
+                        Text("拒绝")
                             .font(.system(size: 13, weight: .medium))
                         Text("\u{2318}N")
                             .font(.system(size: 11, weight: .regular))
@@ -1185,7 +1185,7 @@ struct ChatApprovalBar: View {
                     onApprove()
                 } label: {
                     HStack(spacing: 4) {
-                        Text("Allow")
+                        Text("允许")
                             .font(.system(size: 13, weight: .bold))
                         Text("\u{2318}Y")
                             .font(.system(size: 11, weight: .regular))
@@ -1263,7 +1263,7 @@ struct NewMessagesIndicator: View {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 10, weight: .bold))
 
-                Text(count == 1 ? "1 new message" : "\(count) new messages")
+                Text("\(count) 条新消息")
                     .font(.system(size: 12, weight: .medium))
             }
             .foregroundColor(.white)

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -25,7 +25,7 @@ struct ClaudeInstancesView: View {
             VStack(spacing: 0) {
                 // Top bar: session count left, gear right
                 HStack {
-                    Text("\(sessionMonitor.instances.count) sessions")
+                    Text("\(sessionMonitor.instances.count) 个会话")
                         .font(.system(size: 8))
                         .foregroundColor(.white.opacity(0.2))
                     Spacer()
@@ -58,11 +58,11 @@ struct ClaudeInstancesView: View {
 
     private var emptyState: some View {
         VStack(spacing: 8) {
-            Text("No sessions")
+            Text("暂无会话")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white.opacity(0.4))
 
-            Text("Run claude in terminal")
+            Text("在终端中运行 claude")
                 .font(.system(size: 9))
                 .foregroundColor(.white.opacity(0.25))
         }
@@ -340,7 +340,7 @@ struct InstanceRow: View {
                     .font(.system(size: 9, weight: .medium, design: .monospaced))
                     .foregroundColor(TerminalColors.amber.opacity(0.9))
                 if isInteractiveTool {
-                    Text("Needs your input")
+                    Text("需要你的输入")
                         .font(.system(size: 9))
                         .foregroundColor(.white.opacity(0.5))
                         .lineLimit(1)
@@ -369,7 +369,7 @@ struct InstanceRow: View {
                 }
             case "user":
                 HStack(spacing: 4) {
-                    Text("You:")
+                    Text("你：")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(.white.opacity(0.5))
                     if let msg = session.lastMessage {
@@ -401,14 +401,14 @@ struct InstanceRow: View {
     private var statusLine: some View {
         switch session.phase {
         case .processing:
-            Text("Working...")
+            Text("工作中...")
                 .font(.system(size: 9, weight: .medium))
                 .foregroundColor(TerminalColors.cyan)
         case .waitingForApproval:
             if isInteractiveTool {
                 // Interactive tools: show approval buttons inline on the status line
                 HStack(spacing: 6) {
-                    Text("Needs approval")
+                    Text("需要审批")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(TerminalColors.amber)
                     Spacer()
@@ -420,7 +420,7 @@ struct InstanceRow: View {
                 }
             } else {
                 HStack(spacing: 6) {
-                    Text("Needs approval")
+                    Text("需要审批")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(TerminalColors.amber)
                     Spacer()
@@ -435,17 +435,17 @@ struct InstanceRow: View {
             Button {
                 onFocus()
             } label: {
-                Text("Done \u{2014} click to jump")
+                Text("完成 \u{2014} 点击跳转")
                     .font(.system(size: 9, weight: .medium))
                     .foregroundColor(TerminalColors.green)
             }
             .buttonStyle(.plain)
         case .compacting:
-            Text("Compacting...")
+            Text("压缩中...")
                 .font(.system(size: 9, weight: .medium))
                 .foregroundColor(Self.purple)
         case .idle, .ended:
-            Text("Idle")
+            Text("空闲")
                 .font(.system(size: 9, weight: .medium))
                 .foregroundColor(.white.opacity(0.25))
         }
@@ -476,7 +476,7 @@ struct ProjectGroupHeader: View {
                     .foregroundColor(.white.opacity(0.8))
 
                 if group.activeCount > 0 {
-                    Text("\(group.activeCount) active")
+                    Text("\(group.activeCount) 活跃")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(.white.opacity(0.6))
                         .padding(.horizontal, 6)
@@ -486,7 +486,7 @@ struct ProjectGroupHeader: View {
                                 .fill(Color.white.opacity(0.1))
                         )
                 } else if group.isArchivable {
-                    Text("archived")
+                    Text("已归档")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(.white.opacity(0.35))
                         .padding(.horizontal, 6)
@@ -535,7 +535,7 @@ struct InlineApprovalButtons: View {
             Button {
                 onReject()
             } label: {
-                Text("Deny")
+                Text("拒绝")
                     .font(.system(size: 9, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
                     .padding(.horizontal, 10)
@@ -550,7 +550,7 @@ struct InlineApprovalButtons: View {
             Button {
                 onApprove()
             } label: {
-                Text("Allow")
+                Text("允许")
                     .font(.system(size: 9, weight: .medium))
                     .foregroundColor(.black)
                     .padding(.horizontal, 10)
@@ -617,7 +617,7 @@ struct CompactTerminalButton: View {
             HStack(spacing: 2) {
                 Image(systemName: "terminal")
                     .font(.system(size: 8, weight: .medium))
-                Text("Go to Terminal")
+                Text("前往终端")
                     .font(.system(size: 10, weight: .medium))
             }
             .foregroundColor(isEnabled ? .white.opacity(0.9) : .white.opacity(0.3))
@@ -645,7 +645,7 @@ struct TerminalButton: View {
             HStack(spacing: 3) {
                 Image(systemName: "terminal")
                     .font(.system(size: 9, weight: .medium))
-                Text("Terminal")
+                Text("终端")
                     .font(.system(size: 9, weight: .medium))
             }
             .foregroundColor(isEnabled ? .black : .white.opacity(0.4))

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -25,7 +25,7 @@ struct NotchMenuView: View {
             // Back button
             MenuRow(
                 icon: "chevron.left",
-                label: "Back"
+                label: "返回"
             ) {
                 viewModel.toggleMenu()
             }
@@ -40,7 +40,7 @@ struct NotchMenuView: View {
 
             MenuToggleRow(
                 icon: "folder",
-                label: "Group by Project",
+                label: "按项目分组",
                 isOn: showGrouped
             ) {
                 showGrouped.toggle()
@@ -53,7 +53,7 @@ struct NotchMenuView: View {
             // System settings
             MenuToggleRow(
                 icon: "power",
-                label: "Launch at Login",
+                label: "开机启动",
                 isOn: launchAtLogin
             ) {
                 do {
@@ -71,7 +71,7 @@ struct NotchMenuView: View {
 
             MenuToggleRow(
                 icon: "arrow.triangle.2.circlepath",
-                label: "Hooks",
+                label: "钩子",
                 isOn: hooksInstalled
             ) {
                 if hooksInstalled {
@@ -94,7 +94,7 @@ struct NotchMenuView: View {
 
             MenuRow(
                 icon: "xmark.circle",
-                label: "Quit",
+                label: "退出",
                 isDestructive: true
             ) {
                 NSApplication.shared.terminate(nil)
@@ -136,7 +136,7 @@ struct VersionRow: View {
                 .foregroundColor(.white.opacity(0.7))
                 .frame(width: 16)
 
-            Text("Version")
+            Text("版本")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(.white.opacity(0.7))
 
@@ -172,7 +172,7 @@ struct AccessibilityRow: View {
                 .foregroundColor(textColor)
                 .frame(width: 16)
 
-            Text("Accessibility")
+            Text("辅助功能")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(textColor)
 
@@ -183,12 +183,12 @@ struct AccessibilityRow: View {
                     .fill(TerminalColors.green)
                     .frame(width: 6, height: 6)
 
-                Text("On")
+                Text("已开启")
                     .font(.system(size: 11))
                     .foregroundColor(.white.opacity(0.4))
             } else {
                 Button(action: openAccessibilitySettings) {
-                    Text("Enable")
+                    Text("启用")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(.black)
                         .padding(.horizontal, 10)
@@ -291,7 +291,7 @@ struct MenuToggleRow: View {
                     .fill(isOn ? TerminalColors.green : Color.white.opacity(0.3))
                     .frame(width: 6, height: 6)
 
-                Text(isOn ? "On" : "Off")
+                Text(isOn ? "开" : "关")
                     .font(.system(size: 11))
                     .foregroundColor(.white.opacity(0.4))
             }

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -97,17 +97,17 @@ struct NotchView: View {
         let project = session.projectName
         switch session.phase {
         case .processing:
-            let status = session.lastToolName ?? "working..."
+            let status = session.lastToolName ?? "工作中..."
             return (project, status)
         case .waitingForApproval:
-            let status = session.pendingToolName.map { "approve \($0)?" } ?? "needs approval"
+            let status = session.pendingToolName.map { "审批 \($0)?" } ?? "需要审批"
             return (project, status)
         case .waitingForInput:
-            return (project, "done")
+            return (project, "完成")
         case .compacting:
-            return (project, "compacting...")
+            return (project, "压缩中...")
         case .idle:
-            return (project, "idle")
+            return (project, "空闲")
         case .ended:
             return nil
         }

--- a/ClaudeIsland/UI/Views/SoundSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SoundSettingsView.swift
@@ -15,14 +15,14 @@ struct SoundSettingsView: View {
         VStack(alignment: .leading, spacing: 12) {
             // MARK: - Header
 
-            Text("Sound Settings")
+            Text("声音设置")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(.white)
 
             // MARK: - Global Mute
 
             Toggle(isOn: $soundManager.globalMute) {
-                Label("Mute All Sounds", systemImage: soundManager.globalMute ? "speaker.slash.fill" : "speaker.fill")
+                Label("全部静音", systemImage: soundManager.globalMute ? "speaker.slash.fill" : "speaker.fill")
                     .font(.system(size: 12))
                     .foregroundColor(.white)
             }
@@ -51,7 +51,7 @@ struct SoundSettingsView: View {
 
             // MARK: - Per-Event Toggles
 
-            Text("Event Sounds")
+            Text("事件声音")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.white.opacity(0.6))
 
@@ -101,7 +101,7 @@ private struct SoundEventRow: View {
                     .foregroundColor(.white.opacity(0.7))
             }
             .buttonStyle(.plain)
-            .help("Preview \(event.displayName) sound")
+            .help("预览 \(event.displayName) 声音")
         }
         .onAppear {
             isEnabled = soundManager.isEnabled(event)

--- a/ClaudeIsland/UI/Views/ToolResultViews.swift
+++ b/ClaudeIsland/UI/Views/ToolResultViews.swift
@@ -138,7 +138,7 @@ struct EditResultContent: View {
             }
 
             if result.userModified {
-                Text("(User modified)")
+                Text("(用户已修改)")
                     .font(.system(size: 10))
                     .foregroundColor(.orange.opacity(0.7))
             }
@@ -155,7 +155,7 @@ struct WriteResultContent: View {
         VStack(alignment: .leading, spacing: 6) {
             // Action and filename
             HStack(spacing: 4) {
-                Text(result.type == .create ? "Created" : "Wrote")
+                Text(result.type == .create ? "已创建" : "已写入")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.white.opacity(0.5))
                 Text(result.filename)
@@ -185,7 +185,7 @@ struct BashResultContent: View {
                 HStack(spacing: 4) {
                     Image(systemName: "clock.arrow.circlepath")
                         .font(.system(size: 10))
-                    Text("Background task: \(bgId)")
+                    Text("后台任务: \(bgId)")
                         .font(.system(size: 10, design: .monospaced))
                 }
                 .foregroundColor(.blue.opacity(0.7))
@@ -206,7 +206,7 @@ struct BashResultContent: View {
             // Stderr (shown in red)
             if !result.stderr.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("stderr:")
+                    Text("错误输出：")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(.red.opacity(0.7))
                     Text(result.stderr)
@@ -218,7 +218,7 @@ struct BashResultContent: View {
 
             // Empty state
             if !result.hasOutput && result.backgroundTaskId == nil && result.returnCodeInterpretation == nil {
-                Text("(No content)")
+                Text("(无内容)")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.white.opacity(0.3))
             }
@@ -237,7 +237,7 @@ struct GrepResultContent: View {
             case .filesWithMatches:
                 // Show file list
                 if result.filenames.isEmpty {
-                    Text("No matches found")
+                    Text("未找到匹配")
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundColor(.white.opacity(0.3))
                 } else {
@@ -249,13 +249,13 @@ struct GrepResultContent: View {
                 if let content = result.content, !content.isEmpty {
                     CodePreview(content: content, maxLines: 15)
                 } else {
-                    Text("No matches found")
+                    Text("未找到匹配")
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundColor(.white.opacity(0.3))
                 }
 
             case .count:
-                Text("\(result.numFiles) files with matches")
+                Text("\(result.numFiles) 个文件有匹配")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.white.opacity(0.5))
             }
@@ -271,14 +271,14 @@ struct GlobResultContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             if result.filenames.isEmpty {
-                Text("No files found")
+                Text("未找到文件")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.white.opacity(0.3))
             } else {
                 FileListView(files: result.filenames, limit: 10)
 
                 if result.truncated {
-                    Text("... and more (truncated)")
+                    Text("... 更多（已截断）")
                         .font(.system(size: 10))
                         .foregroundColor(.white.opacity(0.3))
                 }
@@ -349,7 +349,7 @@ struct TaskResultContent: View {
                 }
 
                 if let tools = result.totalToolUseCount {
-                    Text("\(tools) tools")
+                    Text("\(tools) 个工具")
                         .font(.system(size: 10, design: .monospaced))
                         .foregroundColor(.white.opacity(0.4))
                 }
@@ -429,7 +429,7 @@ struct WebSearchResultContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             if result.results.isEmpty {
-                Text("No results found")
+                Text("未找到结果")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.white.opacity(0.3))
             } else {
@@ -450,7 +450,7 @@ struct WebSearchResultContent: View {
                 }
 
                 if result.results.count > 5 {
-                    Text("... and \(result.results.count - 5) more results")
+                    Text("... 还有 \(result.results.count - 5) 个结果")
                         .font(.system(size: 10))
                         .foregroundColor(.white.opacity(0.3))
                 }
@@ -498,12 +498,12 @@ struct BashOutputResultContent: View {
         VStack(alignment: .leading, spacing: 4) {
             // Status
             HStack(spacing: 6) {
-                Text("Status: \(result.status)")
+                Text("状态: \(result.status)")
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(.white.opacity(0.5))
 
                 if let exitCode = result.exitCode {
-                    Text("Exit: \(exitCode)")
+                    Text("退出码: \(exitCode)")
                         .font(.system(size: 10, design: .monospaced))
                         .foregroundColor(exitCode == 0 ? .green.opacity(0.6) : .red.opacity(0.6))
                 }
@@ -535,7 +535,7 @@ struct KillShellResultContent: View {
                 .font(.system(size: 11))
                 .foregroundColor(.red.opacity(0.6))
 
-            Text(result.message.isEmpty ? "Shell \(result.shellId) terminated" : result.message)
+            Text(result.message.isEmpty ? "Shell \(result.shellId) 已终止" : result.message)
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(.white.opacity(0.5))
         }
@@ -610,7 +610,7 @@ struct GenericResultContent: View {
         if let content = result.rawContent, !content.isEmpty {
             GenericTextContent(text: content)
         } else {
-            Text("Completed")
+            Text("已完成")
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(.white.opacity(0.3))
         }
@@ -695,7 +695,7 @@ struct FileCodeView: View {
 
             // Bottom overflow indicator
             if hasMoreAfter {
-                Text("... (\(lines.count - maxLines) more lines)")
+                Text("... (\(lines.count - maxLines) 更多行)")
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(.white.opacity(0.3))
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -753,7 +753,7 @@ struct CodePreview: View {
             }
 
             if hasMore {
-                Text("... (\(lines.count - maxLines) more lines)")
+                Text("... (\(lines.count - maxLines) 更多行)")
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(.white.opacity(0.3))
                     .padding(.top, 2)
@@ -781,7 +781,7 @@ struct FileListView: View {
             }
 
             if files.count > limit {
-                Text("... and \(files.count - limit) more files")
+                Text("... 还有 \(files.count - limit) 个文件")
                     .font(.system(size: 10))
                     .foregroundColor(.white.opacity(0.3))
             }
@@ -807,7 +807,7 @@ struct DiffView: View {
                     }
 
                     if patch.lines.count > 10 {
-                        Text("... (\(patch.lines.count - 10) more lines)")
+                        Text("... (\(patch.lines.count - 10) 更多行)")
                             .font(.system(size: 10, design: .monospaced))
                             .foregroundColor(.white.opacity(0.3))
                     }
@@ -815,7 +815,7 @@ struct DiffView: View {
             }
 
             if patches.count > 3 {
-                Text("... and \(patches.count - 3) more hunks")
+                Text("... 还有 \(patches.count - 3) 个代码块")
                     .font(.system(size: 10))
                     .foregroundColor(.white.opacity(0.3))
             }


### PR DESCRIPTION
## 概要

将 CodeIsland 应用的所有用户界面英文文本翻译为简体中文，涵盖 9 个 Swift 文件、约 90 处字符串。

### 翻译范围

- **菜单项**：返回、按项目分组、开机启动、钩子、辅助功能、版本、退出
- **按钮标签**：允许/拒绝、前往终端、启用
- **状态消息**：工作中、需要审批、完成、压缩中、空闲、已中断
- **会话列表**：暂无会话、在终端中运行 claude、需要你的输入、已归档
- **对话界面**：加载消息中、暂无消息、权限请求、Claude Code 需要你的输入
- **声音设置**：声音设置、全部静音、事件声音、通知声音
- **声音事件名称**：会话开始、开始处理、需要审批、已批准、已拒绝、会话完成、错误、上下文压缩
- **工具结果**：已创建、已写入、后台任务、错误输出、无内容、未找到匹配/文件/结果等
- **屏幕选择**：屏幕、自动、内置、主屏幕
- **刘海状态栏**：工作中、审批、完成、压缩中、空闲

### 修改文件

| 文件 | 修改内容 |
|------|---------|
| `ChatView.swift` | 对话界面所有文本 |
| `ClaudeInstancesView.swift` | 会话列表、审批按钮、状态文本 |
| `NotchMenuView.swift` | 设置菜单所有选项 |
| `NotchView.swift` | 刘海状态栏文本 |
| `SoundSettingsView.swift` | 声音设置界面 |
| `ToolResultViews.swift` | 工具执行结果显示 |
| `ScreenPickerRow.swift` | 屏幕选择器 |
| `SoundPickerRow.swift` | 通知声音选择器 |
| `SoundManager.swift` | 声音事件显示名称 |

## 测试计划

- [x] xcodebuild 编译通过，无 warning 和 error
- [ ] 启动 app 验证刘海显示中文状态
- [ ] 展开面板验证菜单、设置、会话列表中文显示
- [ ] 触发审批流程验证权限请求界面中文显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)