### PR TITLE
feat: Codex hook integration, session tracking, terminal badge, and c…

### DIFF
--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -24,6 +24,8 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var isInTmux: Bool
     /// Detected terminal app name (e.g., "Ghostty", "Warp", "iTerm2", "cmux", "Terminal")
     var terminalApp: String?
+    /// Codex rollout transcript path (non-nil for Codex sessions)
+    var codexTranscriptPath: String?
 
     // MARK: - State Machine
 

--- a/ClaudeIsland/Resources/codeisland-state.py
+++ b/ClaudeIsland/Resources/codeisland-state.py
@@ -49,6 +49,33 @@ def get_tty():
     return None
 
 
+def detect_terminal_app():
+    """Detect terminal from environment variables — more reliable than process tree on macOS."""
+    env = os.environ
+    # Check multiplexers first (innermost layer)
+    if env.get("ZELLIJ") is not None:   # ZELLIJ key present (value may be "0")
+        return "Zellij"
+    if env.get("TMUX"):
+        return "tmux"
+    # Then outer terminal emulator
+    if env.get("GHOSTTY_RESOURCES_DIR") or env.get("TERM_PROGRAM") == "ghostty":
+        return "Ghostty"
+    if env.get("ITERM_SESSION_ID") or env.get("LC_TERMINAL") == "iTerm2":
+        return "iTerm2"
+    term = env.get("TERM_PROGRAM", "").lower()
+    if term == "apple_terminal":
+        return "Terminal"
+    if "warp" in term:
+        return "Warp"
+    if "wezterm" in term:
+        return "WezTerm"
+    if "vscode" in term:
+        return "VS Code"
+    if env.get("CMUX_SOCKET_PATH"):
+        return "cmux"
+    return None
+
+
 def send_event(state):
     """Send event to app, return response if any"""
     try:
@@ -87,6 +114,10 @@ def main():
         sys.exit(0)
     tool_input = data.get("tool_input", {})
 
+    # Detect Codex events: Codex always includes "model" as a required non-optional field.
+    # Claude Code never sends "model" in its hook payload.
+    is_codex = "model" in data
+
     # Get process info
     claude_pid = os.getppid()
     tty = get_tty()
@@ -99,6 +130,19 @@ def main():
         "pid": claude_pid,
         "tty": tty,
     }
+
+    # For non-Codex sessions, send env-detected terminal as a hint for Swift fallback
+    if not is_codex:
+        terminal_hint = detect_terminal_app()
+        if terminal_hint:
+            state["terminal_app"] = terminal_hint
+
+    # For Codex sessions, pass source marker and transcript path
+    if is_codex:
+        state["source"] = "codex"
+        transcript_path = data.get("transcript_path", "")
+        if transcript_path:
+            state["transcript_path"] = transcript_path
 
     # Map events to status
     if event == "UserPromptSubmit":

--- a/ClaudeIsland/Services/Hooks/CodexHookInstallationManager.swift
+++ b/ClaudeIsland/Services/Hooks/CodexHookInstallationManager.swift
@@ -1,0 +1,184 @@
+//
+//  CodexHookInstallationManager.swift
+//  ClaudeIsland
+//
+//  Manages installing/uninstalling Code Island as a Codex hook provider.
+//  Writes to ~/.codex/config.toml (feature flag) and ~/.codex/hooks.json (hook entries).
+//
+
+import Foundation
+
+struct CodexHookInstallationStatus: Equatable, Sendable {
+    var codexDirectory: URL
+    var configURL: URL
+    var hooksURL: URL
+    var manifestURL: URL
+    /// Path to the hook script/binary that was installed, if known.
+    var hookScriptPath: String?
+    var featureFlagEnabled: Bool
+    var managedHooksPresent: Bool
+    var manifest: CodexHookInstallerManifest?
+}
+
+/// Manages the full lifecycle of Code Island's Codex hook installation.
+///
+/// Usage:
+///   let manager = CodexHookInstallationManager()
+///   try manager.install(hookScriptPath: "/path/to/codeisland-state.py")
+///   try manager.uninstall()
+final class CodexHookInstallationManager: @unchecked Sendable {
+    let codexDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        codexDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true),
+        fileManager: FileManager = .default
+    ) {
+        self.codexDirectory = codexDirectory
+        self.fileManager = fileManager
+    }
+
+    func status(hookScriptPath: String? = nil) throws -> CodexHookInstallationStatus {
+        let configURL = codexDirectory.appendingPathComponent("config.toml")
+        let hooksURL = codexDirectory.appendingPathComponent("hooks.json")
+        let manifestURL = resolvedManifestURL()
+
+        let configContents = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let hooksData = try? Data(contentsOf: hooksURL)
+        let manifest = try loadManifest(at: manifestURL)
+        let managedCommand = manifest?.hookCommand
+            ?? hookScriptPath.map { CodexHookInstaller.hookCommand(for: $0) }
+        let managedHooksPresent = ((try? CodexHookInstaller.uninstallHooksJSON(
+            existingData: hooksData,
+            managedCommand: managedCommand
+        ))?.changed) == true
+
+        return CodexHookInstallationStatus(
+            codexDirectory: codexDirectory,
+            configURL: configURL,
+            hooksURL: hooksURL,
+            manifestURL: manifestURL,
+            hookScriptPath: hookScriptPath,
+            featureFlagEnabled: configContents.contains("codex_hooks = true"),
+            managedHooksPresent: managedHooksPresent,
+            manifest: manifest
+        )
+    }
+
+    @discardableResult
+    func install(hookScriptPath: String) throws -> CodexHookInstallationStatus {
+        try fileManager.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
+
+        let configURL = codexDirectory.appendingPathComponent("config.toml")
+        let hooksURL = codexDirectory.appendingPathComponent("hooks.json")
+        let manifestURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.fileName)
+        let legacyManifestURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.legacyFileName)
+
+        let existingConfig = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let existingHooks = try? Data(contentsOf: hooksURL)
+
+        let command = CodexHookInstaller.hookCommand(for: hookScriptPath)
+        let featureMutation = CodexHookInstaller.enableCodexHooksFeature(in: existingConfig)
+        let hooksMutation = try CodexHookInstaller.installHooksJSON(existingData: existingHooks, hookCommand: command)
+
+        if featureMutation.changed, fileManager.fileExists(atPath: configURL.path) {
+            try backupFile(at: configURL)
+        }
+        if hooksMutation.changed, fileManager.fileExists(atPath: hooksURL.path) {
+            try backupFile(at: hooksURL)
+        }
+
+        try featureMutation.contents.write(to: configURL, atomically: true, encoding: .utf8)
+        if let hooksData = hooksMutation.contents {
+            try hooksData.write(to: hooksURL, options: .atomic)
+        }
+
+        let manifest = CodexHookInstallerManifest(
+            hookCommand: command,
+            enabledCodexHooksFeature: featureMutation.featureEnabledByInstaller
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+
+        if fileManager.fileExists(atPath: legacyManifestURL.path) {
+            try fileManager.removeItem(at: legacyManifestURL)
+        }
+
+        return try status(hookScriptPath: hookScriptPath)
+    }
+
+    @discardableResult
+    func uninstall() throws -> CodexHookInstallationStatus {
+        let configURL = codexDirectory.appendingPathComponent("config.toml")
+        let hooksURL = codexDirectory.appendingPathComponent("hooks.json")
+        let manifestURL = resolvedManifestURL()
+        let primaryManifestURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.fileName)
+        let legacyManifestURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.legacyFileName)
+
+        let manifest = try loadManifest(at: manifestURL)
+        let existingHooks = try? Data(contentsOf: hooksURL)
+        let hooksMutation = try CodexHookInstaller.uninstallHooksJSON(
+            existingData: existingHooks,
+            managedCommand: manifest?.hookCommand
+        )
+
+        if hooksMutation.changed, fileManager.fileExists(atPath: hooksURL.path) {
+            try backupFile(at: hooksURL)
+        }
+
+        if let hooksData = hooksMutation.contents {
+            try hooksData.write(to: hooksURL, options: .atomic)
+        } else if fileManager.fileExists(atPath: hooksURL.path) {
+            try fileManager.removeItem(at: hooksURL)
+        }
+
+        if let manifest, manifest.enabledCodexHooksFeature, !hooksMutation.hasRemainingHooks {
+            let existingConfig = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+            let featureMutation = CodexHookInstaller.disableCodexHooksFeatureIfManaged(in: existingConfig)
+            if featureMutation.changed {
+                if fileManager.fileExists(atPath: configURL.path) {
+                    try backupFile(at: configURL)
+                }
+                try featureMutation.contents.write(to: configURL, atomically: true, encoding: .utf8)
+            }
+        }
+
+        for candidate in [primaryManifestURL, legacyManifestURL] where fileManager.fileExists(atPath: candidate.path) {
+            try fileManager.removeItem(at: candidate)
+        }
+
+        return try status()
+    }
+
+    // MARK: - Private
+
+    private func loadManifest(at url: URL) throws -> CodexHookInstallerManifest? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(CodexHookInstallerManifest.self, from: data)
+    }
+
+    private func resolvedManifestURL() -> URL {
+        let primaryURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.fileName)
+        if fileManager.fileExists(atPath: primaryURL.path) { return primaryURL }
+        let legacyURL = codexDirectory.appendingPathComponent(CodexHookInstallerManifest.legacyFileName)
+        return fileManager.fileExists(atPath: legacyURL.path) ? legacyURL : primaryURL
+    }
+
+    private func backupFile(at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let timestamp = formatter.string(from: .now).replacingOccurrences(of: ":", with: "-")
+        let backupURL = url.appendingPathExtension("backup.\(timestamp)")
+        if fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.removeItem(at: backupURL)
+        }
+        try fileManager.copyItem(at: url, to: backupURL)
+    }
+}

--- a/ClaudeIsland/Services/Hooks/CodexHookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/CodexHookInstaller.swift
@@ -1,0 +1,303 @@
+//
+//  CodexHookInstaller.swift
+//  ClaudeIsland
+//
+//  Low-level logic for installing/uninstalling Code Island hooks
+//  into Codex's hooks.json and config.toml.
+//
+
+import Foundation
+
+struct CodexHookInstallerManifest: Equatable, Codable, Sendable {
+    static let fileName = "code-island-codex-install.json"
+    static let legacyFileName = "open-island-codex-install.json"
+
+    var hookCommand: String
+    var enabledCodexHooksFeature: Bool
+    var installedAt: Date
+
+    init(hookCommand: String, enabledCodexHooksFeature: Bool, installedAt: Date = .now) {
+        self.hookCommand = hookCommand
+        self.enabledCodexHooksFeature = enabledCodexHooksFeature
+        self.installedAt = installedAt
+    }
+}
+
+struct CodexFeatureMutation: Equatable, Sendable {
+    var contents: String
+    var changed: Bool
+    var featureEnabledByInstaller: Bool
+}
+
+struct CodexHookFileMutation: Equatable, Sendable {
+    var contents: Data?
+    var changed: Bool
+    var hasRemainingHooks: Bool
+}
+
+enum CodexHookInstallerError: Error, LocalizedError {
+    case invalidHooksJSON
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidHooksJSON:
+            "The existing Codex hooks file is not valid JSON."
+        }
+    }
+}
+
+enum CodexHookInstaller {
+    static let managedStatusMessage = "Managed by Code Island"
+    static let legacyManagedStatusMessage = "Managed by Open Island"
+    static let managedTimeout = 45
+
+    private static let eventSpecs: [(name: String, matcher: String?)] = [
+        ("SessionStart", "startup|resume"),
+        ("UserPromptSubmit", nil),
+        ("Stop", nil),
+    ]
+
+    static func hookCommand(for scriptPath: String) -> String {
+        shellQuote(scriptPath)
+    }
+
+    static func installHooksJSON(existingData: Data?, hookCommand: String) throws -> CodexHookFileMutation {
+        var rootObject = try loadRootObject(from: existingData)
+        let existingHooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+        var hooksObject: [String: Any] = [:]
+
+        for (eventName, value) in existingHooksObject {
+            let existingGroups = value as? [Any] ?? []
+            let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
+            if !cleanedGroups.isEmpty {
+                hooksObject[eventName] = cleanedGroups
+            }
+        }
+
+        for spec in eventSpecs {
+            let existingGroups = hooksObject[spec.name] as? [Any] ?? []
+            let cleanedGroups = sanitizeForInstall(groups: existingGroups, replacingCommand: hookCommand)
+            hooksObject[spec.name] = cleanedGroups + [managedGroup(matcher: spec.matcher, hookCommand: hookCommand)]
+        }
+
+        rootObject["hooks"] = hooksObject
+        let data = try serialize(rootObject)
+        return CodexHookFileMutation(contents: data, changed: data != existingData, hasRemainingHooks: true)
+    }
+
+    static func uninstallHooksJSON(existingData: Data?, managedCommand: String?) throws -> CodexHookFileMutation {
+        guard let existingData else {
+            return CodexHookFileMutation(contents: nil, changed: false, hasRemainingHooks: false)
+        }
+
+        var rootObject = try loadRootObject(from: existingData)
+        var hooksObject = rootObject["hooks"] as? [String: Any] ?? [:]
+        var mutated = false
+
+        for spec in eventSpecs {
+            let existingGroups = hooksObject[spec.name] as? [Any] ?? []
+            let cleanedGroups = sanitize(groups: existingGroups, managedCommand: managedCommand)
+
+            if cleanedGroups.count != existingGroups.count || containsManagedHook(in: existingGroups, managedCommand: managedCommand) {
+                mutated = true
+            }
+
+            if cleanedGroups.isEmpty {
+                hooksObject.removeValue(forKey: spec.name)
+            } else {
+                hooksObject[spec.name] = cleanedGroups
+            }
+        }
+
+        if hooksObject.isEmpty {
+            return CodexHookFileMutation(contents: nil, changed: mutated, hasRemainingHooks: false)
+        }
+
+        rootObject["hooks"] = hooksObject
+        let data = try serialize(rootObject)
+        return CodexHookFileMutation(contents: data, changed: mutated || data != existingData, hasRemainingHooks: true)
+    }
+
+    static func enableCodexHooksFeature(in contents: String) -> CodexFeatureMutation {
+        var lines = contents.components(separatedBy: "\n")
+
+        if let codexHookIndex = lineIndex(ofKey: "codex_hooks", inSection: "features", lines: lines) {
+            let trimmed = lines[codexHookIndex].trimmingCharacters(in: .whitespaces)
+            if trimmed == "codex_hooks = true" {
+                return CodexFeatureMutation(contents: contents, changed: false, featureEnabledByInstaller: false)
+            }
+            lines[codexHookIndex] = "codex_hooks = true"
+            return CodexFeatureMutation(
+                contents: lines.joined(separator: "\n"),
+                changed: true,
+                featureEnabledByInstaller: true
+            )
+        }
+
+        if let featuresRange = sectionRange(named: "features", lines: lines) {
+            lines.insert("codex_hooks = true", at: featuresRange.upperBound)
+            return CodexFeatureMutation(
+                contents: lines.joined(separator: "\n"),
+                changed: true,
+                featureEnabledByInstaller: true
+            )
+        }
+
+        if !lines.isEmpty, lines.last?.isEmpty == false {
+            lines.append("")
+        }
+        lines.append("[features]")
+        lines.append("codex_hooks = true")
+
+        return CodexFeatureMutation(
+            contents: lines.joined(separator: "\n"),
+            changed: true,
+            featureEnabledByInstaller: true
+        )
+    }
+
+    static func disableCodexHooksFeatureIfManaged(in contents: String) -> CodexFeatureMutation {
+        var lines = contents.components(separatedBy: "\n")
+        guard let featuresRange = sectionRange(named: "features", lines: lines),
+              let codexHookIndex = lineIndex(ofKey: "codex_hooks", inSection: "features", lines: lines) else {
+            return CodexFeatureMutation(contents: contents, changed: false, featureEnabledByInstaller: false)
+        }
+
+        lines.remove(at: codexHookIndex)
+
+        let updatedRange = sectionRange(named: "features", lines: lines) ?? featuresRange
+        let remainingFeatureLines = lines[updatedRange.lowerBound + 1 ..< updatedRange.upperBound]
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+
+        if remainingFeatureLines.isEmpty, let featuresHeaderIndex = lines.firstIndex(of: "[features]") {
+            lines.remove(at: featuresHeaderIndex)
+            if featuresHeaderIndex < lines.count, lines[featuresHeaderIndex].isEmpty {
+                lines.remove(at: featuresHeaderIndex)
+            }
+        }
+
+        return CodexFeatureMutation(contents: lines.joined(separator: "\n"), changed: true, featureEnabledByInstaller: false)
+    }
+
+    // MARK: - Private Helpers
+
+    private static func loadRootObject(from data: Data?) throws -> [String: Any] {
+        guard let data else { return [:] }
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let rootObject = object as? [String: Any] else {
+            throw CodexHookInstallerError.invalidHooksJSON
+        }
+        return rootObject
+    }
+
+    private static func serialize(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func sanitize(groups: [Any], managedCommand: String?) -> [[String: Any]] {
+        groups.compactMap { item in
+            guard var group = item as? [String: Any] else { return nil }
+            let existingHooks = group["hooks"] as? [Any] ?? []
+            let filteredHooks = existingHooks.compactMap { hook -> [String: Any]? in
+                guard let hook = hook as? [String: Any] else { return nil }
+                return isManagedHook(hook, managedCommand: managedCommand) ? nil : hook
+            }
+            guard !filteredHooks.isEmpty else { return nil }
+            group["hooks"] = filteredHooks
+            return group
+        }
+    }
+
+    private static func sanitizeForInstall(groups: [Any], replacingCommand: String) -> [[String: Any]] {
+        groups.compactMap { item in
+            guard var group = item as? [String: Any] else { return nil }
+            let existingHooks = group["hooks"] as? [Any] ?? []
+            let filteredHooks = existingHooks.compactMap { hook -> [String: Any]? in
+                guard let hook = hook as? [String: Any] else { return nil }
+                return isManagedHookForInstall(hook, replacingCommand: replacingCommand) ? nil : hook
+            }
+            guard !filteredHooks.isEmpty else { return nil }
+            group["hooks"] = filteredHooks
+            return group
+        }
+    }
+
+    private static func containsManagedHook(in groups: [Any], managedCommand: String?) -> Bool {
+        groups.contains { item in
+            guard let group = item as? [String: Any],
+                  let hooks = group["hooks"] as? [Any] else { return false }
+            return hooks.contains { hook in
+                guard let hook = hook as? [String: Any] else { return false }
+                return isManagedHook(hook, managedCommand: managedCommand)
+            }
+        }
+    }
+
+    private static func managedGroup(matcher: String?, hookCommand: String) -> [String: Any] {
+        var group: [String: Any] = [
+            "hooks": [[
+                "type": "command",
+                "command": hookCommand,
+                "timeout": managedTimeout,
+            ] as [String: Any]]
+        ]
+        if let matcher { group["matcher"] = matcher }
+        return group
+    }
+
+    private static func isManagedHook(_ hook: [String: Any], managedCommand: String?) -> Bool {
+        if let statusMessage = hook["statusMessage"] as? String,
+           statusMessage == managedStatusMessage || statusMessage == legacyManagedStatusMessage {
+            return true
+        }
+        guard let managedCommand else { return false }
+        return hook["command"] as? String == managedCommand
+    }
+
+    private static func isManagedHookForInstall(_ hook: [String: Any], replacingCommand: String) -> Bool {
+        if isManagedHook(hook, managedCommand: replacingCommand) { return true }
+        guard let command = hook["command"] as? String else { return false }
+        return isLegacyIslandHookCommand(command)
+    }
+
+    private static func isLegacyIslandHookCommand(_ command: String) -> Bool {
+        let normalized = command.lowercased()
+        return normalized.contains("openislandhooks")
+            || normalized.contains("vibeislandhooks")
+            || normalized.contains("open-island-bridge")
+            || normalized.contains("vibe-island-bridge")
+    }
+
+    private static func sectionRange(named section: String, lines: [String]) -> Range<Int>? {
+        guard let headerIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == "[\(section)]"
+        }) else { return nil }
+
+        var endIndex = lines.count
+        for index in (headerIndex + 1) ..< lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                endIndex = index
+                break
+            }
+        }
+        return headerIndex ..< endIndex
+    }
+
+    private static func lineIndex(ofKey key: String, inSection section: String, lines: [String]) -> Int? {
+        guard let range = sectionRange(named: section, lines: lines) else { return nil }
+        for index in (range.lowerBound + 1) ..< range.upperBound {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("\(key) =") { return index }
+        }
+        return nil
+    }
+
+    private static func shellQuote(_ string: String) -> String {
+        guard !string.isEmpty else { return "''" }
+        let needsQuoting = string.contains(where: { " \t\n\"'\\$`!".contains($0) })
+        guard needsQuoting else { return string }
+        return "'\(string.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -12,7 +12,7 @@ import os.log
 /// Logger for hook socket server
 private let logger = Logger(subsystem: "com.codeisland", category: "Hooks")
 
-/// Event received from Claude Code hooks
+/// Event received from Claude Code or Codex hooks
 struct HookEvent: Codable, Sendable {
     let sessionId: String
     let cwd: String
@@ -25,6 +25,12 @@ struct HookEvent: Codable, Sendable {
     let toolUseId: String?
     let notificationType: String?
     let message: String?
+    /// "codex" for Codex hook events; nil for Claude Code hook events
+    let source: String?
+    /// Rollout file path for Codex sessions (passed via transcript_path)
+    let transcriptPath: String?
+    /// Env-detected terminal app hint from hook script (fallback when process tree fails)
+    let terminalApp: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -32,11 +38,13 @@ struct HookEvent: Codable, Sendable {
         case toolInput = "tool_input"
         case toolUseId = "tool_use_id"
         case notificationType = "notification_type"
-        case message
+        case message, source
+        case transcriptPath = "transcript_path"
+        case terminalApp = "terminal_app"
     }
 
     /// Create a copy with updated toolUseId
-    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?) {
+    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?, source: String? = nil, transcriptPath: String? = nil, terminalApp: String? = nil) {
         self.sessionId = sessionId
         self.cwd = cwd
         self.event = event
@@ -48,6 +56,9 @@ struct HookEvent: Codable, Sendable {
         self.toolUseId = toolUseId
         self.notificationType = notificationType
         self.message = message
+        self.source = source
+        self.transcriptPath = transcriptPath
+        self.terminalApp = terminalApp
     }
 
     var sessionPhase: SessionPhase {

--- a/ClaudeIsland/Services/Session/CodexChatHistoryParser.swift
+++ b/ClaudeIsland/Services/Session/CodexChatHistoryParser.swift
@@ -1,0 +1,118 @@
+//
+//  CodexChatHistoryParser.swift
+//  ClaudeIsland
+//
+//  Parses Codex rollout JSONL files into ChatMessage objects for display in ChatView.
+//  Prefers response_item entries (full API format) over event_msg summaries.
+//
+
+import Foundation
+
+enum CodexChatHistoryParser {
+
+    /// Parse a rollout JSONL file into an ordered array of ChatMessages.
+    static func parse(transcriptPath: String) -> [ChatMessage] {
+        guard let contents = try? String(contentsOf: URL(fileURLWithPath: transcriptPath), encoding: .utf8)
+        else { return [] }
+
+        var messages: [ChatMessage] = []
+        var counter = 0
+
+        // First pass: collect response_item messages (authoritative, full content)
+        contents.enumerateLines { line, _ in
+            guard let object = jsonObject(for: line),
+                  object["type"] as? String == "response_item" else { return }
+            let timestamp = parseTimestamp(object["timestamp"] as? String) ?? Date()
+            let payload = object["payload"] as? [String: Any] ?? [:]
+            if let msg = parseResponseItem(payload, timestamp: timestamp, counter: &counter) {
+                messages.append(msg)
+            }
+        }
+
+        // Fall back to event_msg stream if no response_item messages were found
+        if messages.isEmpty {
+            contents.enumerateLines { line, _ in
+                guard let object = jsonObject(for: line),
+                      object["type"] as? String == "event_msg" else { return }
+                let timestamp = parseTimestamp(object["timestamp"] as? String) ?? Date()
+                let payload = object["payload"] as? [String: Any] ?? [:]
+                if let msg = parseEventMsg(payload, timestamp: timestamp, counter: &counter) {
+                    messages.append(msg)
+                }
+            }
+        }
+
+        return messages
+    }
+
+    // MARK: - Private
+
+    private static func parseResponseItem(
+        _ payload: [String: Any],
+        timestamp: Date,
+        counter: inout Int
+    ) -> ChatMessage? {
+        guard payload["type"] as? String == "message",
+              let roleStr = payload["role"] as? String,
+              let contentArray = payload["content"] as? [[String: Any]] else { return nil }
+
+        let role: ChatRole = roleStr == "user" ? .user : .assistant
+        let textType = roleStr == "user" ? "input_text" : "output_text"
+
+        var blocks: [MessageBlock] = []
+        for item in contentArray {
+            guard item["type"] as? String == textType,
+                  let text = item["text"] as? String else { continue }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if role == .user, isInjectedBlock(trimmed) { continue }
+            blocks.append(.text(trimmed))
+        }
+        guard !blocks.isEmpty else { return nil }
+
+        counter += 1
+        return ChatMessage(id: "codex-\(counter)", role: role, timestamp: timestamp, content: blocks)
+    }
+
+    private static func parseEventMsg(
+        _ payload: [String: Any],
+        timestamp: Date,
+        counter: inout Int
+    ) -> ChatMessage? {
+        guard let msgType = payload["type"] as? String,
+              let text = payload["message"] as? String,
+              !text.isEmpty else { return nil }
+
+        let role: ChatRole
+        switch msgType {
+        case "user_message": role = .user
+        case "agent_message": role = .assistant
+        default: return nil
+        }
+
+        counter += 1
+        return ChatMessage(id: "codex-evt-\(counter)", role: role, timestamp: timestamp, content: [.text(text)])
+    }
+
+    private static func isInjectedBlock(_ text: String) -> Bool {
+        text.hasPrefix("# AGENTS.md instructions for ")
+            || text.hasPrefix("<environment_context>")
+            || text.hasPrefix("<permissions instructions>")
+            || text.hasPrefix("<collaboration_mode>")
+            || text.hasPrefix("<skills_instructions>")
+    }
+
+    private static func jsonObject(for line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any] else { return nil }
+        return dictionary
+    }
+
+    private static func parseTimestamp(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string)
+    }
+}

--- a/ClaudeIsland/Services/Session/CodexHooks.swift
+++ b/ClaudeIsland/Services/Session/CodexHooks.swift
@@ -1,0 +1,532 @@
+//
+//  CodexHooks.swift
+//  ClaudeIsland
+//
+//  Codex hook payload models and runtime context enrichment.
+//  Mirrors the Codex hook JSON schema for SessionStart, UserPromptSubmit, and Stop events.
+//
+
+import Foundation
+
+// MARK: - Hook Event Names
+
+enum CodexHookEventName: String, Codable, Sendable {
+    case sessionStart = "SessionStart"
+    case preToolUse = "PreToolUse"
+    case postToolUse = "PostToolUse"
+    case userPromptSubmit = "UserPromptSubmit"
+    case stop = "Stop"
+}
+
+// MARK: - Permission Mode
+
+enum CodexPermissionMode: String, Codable, Sendable {
+    case `default`
+    case acceptEdits
+    case plan
+    case dontAsk
+    case bypassPermissions
+}
+
+// MARK: - Tool Input
+
+struct CodexHookToolInput: Equatable, Codable, Sendable {
+    var command: String
+
+    init(command: String) {
+        self.command = command
+    }
+}
+
+// MARK: - Dynamic JSON Value
+
+enum CodexHookJSONValue: Equatable, Codable, Sendable {
+    case string(String)
+    case number(Double)
+    case boolean(Bool)
+    case object([String: CodexHookJSONValue])
+    case array([CodexHookJSONValue])
+    case null
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String: CodexHookJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([CodexHookJSONValue].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value.")
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .string(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .boolean(value): try container.encode(value)
+        case let .object(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+}
+
+// MARK: - Hook Payload
+
+struct CodexHookPayload: Equatable, Codable, Sendable {
+    var cwd: String
+    var hookEventName: CodexHookEventName
+    var model: String
+    var permissionMode: CodexPermissionMode
+    var sessionID: String
+    var terminalApp: String?
+    var terminalSessionID: String?
+    var terminalTTY: String?
+    var terminalTitle: String?
+    var transcriptPath: String?
+    var source: String?
+    var turnID: String?
+    var toolName: String?
+    var toolUseID: String?
+    var toolInput: CodexHookToolInput?
+    var toolResponse: CodexHookJSONValue?
+    var prompt: String?
+    var stopHookActive: Bool?
+    var lastAssistantMessage: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case cwd
+        case hookEventName = "hook_event_name"
+        case model
+        case permissionMode = "permission_mode"
+        case sessionID = "session_id"
+        case terminalApp = "terminal_app"
+        case terminalSessionID = "terminal_session_id"
+        case terminalTTY = "terminal_tty"
+        case terminalTitle = "terminal_title"
+        case transcriptPath = "transcript_path"
+        case source
+        case turnID = "turn_id"
+        case toolName = "tool_name"
+        case toolUseID = "tool_use_id"
+        case toolInput = "tool_input"
+        case toolResponse = "tool_response"
+        case prompt
+        case stopHookActive = "stop_hook_active"
+        case lastAssistantMessage = "last_assistant_message"
+    }
+
+    init(
+        cwd: String,
+        hookEventName: CodexHookEventName,
+        model: String,
+        permissionMode: CodexPermissionMode,
+        sessionID: String,
+        terminalApp: String? = nil,
+        terminalSessionID: String? = nil,
+        terminalTTY: String? = nil,
+        terminalTitle: String? = nil,
+        transcriptPath: String? = nil,
+        source: String? = nil,
+        turnID: String? = nil,
+        toolName: String? = nil,
+        toolUseID: String? = nil,
+        toolInput: CodexHookToolInput? = nil,
+        toolResponse: CodexHookJSONValue? = nil,
+        prompt: String? = nil,
+        stopHookActive: Bool? = nil,
+        lastAssistantMessage: String? = nil
+    ) {
+        self.cwd = cwd
+        self.hookEventName = hookEventName
+        self.model = model
+        self.permissionMode = permissionMode
+        self.sessionID = sessionID
+        self.terminalApp = terminalApp
+        self.terminalSessionID = terminalSessionID
+        self.terminalTTY = terminalTTY
+        self.terminalTitle = terminalTitle
+        self.transcriptPath = transcriptPath
+        self.source = source
+        self.turnID = turnID
+        self.toolName = toolName
+        self.toolUseID = toolUseID
+        self.toolInput = toolInput
+        self.toolResponse = toolResponse
+        self.prompt = prompt
+        self.stopHookActive = stopHookActive
+        self.lastAssistantMessage = lastAssistantMessage
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cwd = try container.decode(String.self, forKey: .cwd)
+        hookEventName = try container.decode(CodexHookEventName.self, forKey: .hookEventName)
+        model = try container.decode(String.self, forKey: .model)
+        permissionMode = try container.decodeIfPresent(CodexPermissionMode.self, forKey: .permissionMode) ?? .default
+        sessionID = try container.decode(String.self, forKey: .sessionID)
+        terminalApp = try container.decodeIfPresent(String.self, forKey: .terminalApp)
+        terminalSessionID = try container.decodeIfPresent(String.self, forKey: .terminalSessionID)
+        terminalTTY = try container.decodeIfPresent(String.self, forKey: .terminalTTY)
+        terminalTitle = try container.decodeIfPresent(String.self, forKey: .terminalTitle)
+        transcriptPath = try container.decodeIfPresent(String.self, forKey: .transcriptPath)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        turnID = try container.decodeIfPresent(String.self, forKey: .turnID)
+        toolName = try container.decodeIfPresent(String.self, forKey: .toolName)
+        toolUseID = try container.decodeIfPresent(String.self, forKey: .toolUseID)
+        toolInput = try container.decodeIfPresent(CodexHookToolInput.self, forKey: .toolInput)
+        toolResponse = try container.decodeIfPresent(CodexHookJSONValue.self, forKey: .toolResponse)
+        prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
+        stopHookActive = try container.decodeIfPresent(Bool.self, forKey: .stopHookActive)
+        lastAssistantMessage = try container.decodeIfPresent(String.self, forKey: .lastAssistantMessage)
+    }
+}
+
+// MARK: - Derived Properties
+
+extension CodexHookPayload {
+    var workspaceName: String {
+        CodexWorkspaceNameResolver.workspaceName(for: cwd)
+    }
+
+    var worktreeBranch: String? {
+        CodexWorkspaceNameResolver.worktreeBranch(for: cwd)
+    }
+
+    var sessionTitle: String {
+        "Codex · \(workspaceName)"
+    }
+
+    var defaultCodexMetadata: CodexSessionMetadata {
+        CodexSessionMetadata(
+            transcriptPath: transcriptPath,
+            initialUserPrompt: prompt ?? promptPreview,
+            lastUserPrompt: prompt ?? promptPreview,
+            lastAssistantMessage: lastAssistantMessage,
+            currentTool: toolName,
+            currentCommandPreview: commandPreview
+        )
+    }
+
+    var implicitStartSummary: String {
+        switch hookEventName {
+        case .sessionStart:
+            if source == "resume" {
+                return "Resumed Codex session in \(workspaceName)."
+            }
+            return "Started Codex session in \(workspaceName)."
+        case .preToolUse:
+            return "Codex is preparing a Bash command in \(workspaceName)."
+        case .postToolUse:
+            return "Codex reported a Bash result in \(workspaceName)."
+        case .userPromptSubmit:
+            return "Codex received a new prompt in \(workspaceName)."
+        case .stop:
+            return "Codex completed a turn in \(workspaceName)."
+        }
+    }
+
+    var commandText: String? { toolInput?.command }
+    var commandPreview: String? { clipped(commandText) }
+    var promptPreview: String? { clipped(prompt) }
+    var assistantMessagePreview: String? { clipped(lastAssistantMessage) }
+
+    var toolResponsePreview: String? {
+        guard let toolResponse else { return nil }
+        return clipped(stringValue(for: toolResponse))
+    }
+
+    private func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else { return nil }
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+        guard collapsed.count > limit else { return collapsed }
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+
+    private func stringValue(for value: CodexHookJSONValue) -> String {
+        switch value {
+        case let .string(text): return text
+        case let .number(number): return String(number)
+        case let .boolean(flag): return flag ? "true" : "false"
+        case .null: return "null"
+        case let .array(items):
+            return "[\(items.map(stringValue(for:)).joined(separator: ", "))]"
+        case let .object(object):
+            let rendered = object.keys.sorted()
+                .map { key in "\(key): \(object[key].map(stringValue(for:)) ?? "null")" }
+                .joined(separator: ", ")
+            return "{\(rendered)}"
+        }
+    }
+}
+
+// MARK: - Runtime Context Enrichment
+
+extension CodexHookPayload {
+    func withRuntimeContext(environment: [String: String]) -> CodexHookPayload {
+        withRuntimeContext(
+            environment: environment,
+            currentTTYProvider: { currentTTY() },
+            terminalLocatorProvider: { terminalLocator(for: $0) }
+        )
+    }
+
+    func withRuntimeContext(
+        environment: [String: String],
+        currentTTYProvider: () -> String?,
+        terminalLocatorProvider: (String) -> (sessionID: String?, tty: String?, title: String?)
+    ) -> CodexHookPayload {
+        var payload = self
+
+        if payload.terminalApp == nil {
+            payload.terminalApp = inferTerminalApp(from: environment)
+        }
+
+        if payload.terminalApp == "cmux", payload.terminalSessionID == nil {
+            payload.terminalSessionID = environment["CMUX_SURFACE_ID"]
+        }
+
+        if isZellijTerminalApp(payload.terminalApp), payload.terminalSessionID == nil {
+            let paneID = environment["ZELLIJ_PANE_ID"] ?? ""
+            let sessionName = environment["ZELLIJ_SESSION_NAME"] ?? ""
+            if !paneID.isEmpty {
+                payload.terminalSessionID = "\(paneID):\(sessionName)"
+            }
+        }
+
+        if payload.terminalTTY == nil {
+            payload.terminalTTY = currentTTYProvider()
+        }
+
+        let useLocator: Bool
+        if isCmuxTerminalApp(payload.terminalApp) || isZellijTerminalApp(payload.terminalApp) {
+            useLocator = false
+        } else if let terminalApp = payload.terminalApp, isGhosttyTerminalApp(terminalApp) {
+            if payload.hookEventName == .sessionStart || payload.hookEventName == .userPromptSubmit {
+                useLocator = true
+            } else {
+                payload.terminalSessionID = nil
+                payload.terminalTitle = nil
+                useLocator = false
+            }
+        } else {
+            useLocator = shouldUseFocusedTerminalLocator(for: payload.terminalApp ?? "")
+        }
+
+        if useLocator, let terminalApp = payload.terminalApp {
+            let locator = terminalLocatorProvider(terminalApp)
+            if payload.terminalSessionID == nil { payload.terminalSessionID = locator.sessionID }
+            if payload.terminalTTY == nil { payload.terminalTTY = locator.tty }
+            if payload.terminalTitle == nil { payload.terminalTitle = locator.title }
+        }
+
+        return payload
+    }
+
+    private static let noLocatorTerminalApps: Set<String> = [
+        "cmux", "kaku", "wezterm", "zellij",
+        "vs code", "vs code insiders", "cursor", "windsurf", "trae",
+        "intellij idea", "webstorm", "pycharm", "goland", "clion",
+        "rubymine", "phpstorm", "rider", "rustrover",
+    ]
+
+    private func shouldUseFocusedTerminalLocator(for terminalApp: String) -> Bool {
+        let lower = terminalApp.lowercased()
+        if lower.contains("ghostty") || lower.contains("jetbrains") { return false }
+        return !Self.noLocatorTerminalApps.contains(lower)
+    }
+
+    private func isGhosttyTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased().contains("ghostty") ?? false
+    }
+
+    private func isCmuxTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "cmux"
+    }
+
+    private func isZellijTerminalApp(_ terminalApp: String?) -> Bool {
+        terminalApp?.lowercased() == "zellij"
+    }
+
+    private func inferTerminalApp(from environment: [String: String]) -> String? {
+        if environment["ITERM_SESSION_ID"] != nil || environment["LC_TERMINAL"] == "iTerm2" { return "iTerm" }
+        if environment["CMUX_WORKSPACE_ID"] != nil || environment["CMUX_SOCKET_PATH"] != nil { return "cmux" }
+        if environment["ZELLIJ"] != nil { return "Zellij" }
+        if environment["GHOSTTY_RESOURCES_DIR"] != nil { return "Ghostty" }
+        if environment["WARP_IS_LOCAL_SHELL_SESSION"] != nil { return "Warp" }
+
+        let termProgram = environment["TERM_PROGRAM"]?.lowercased()
+        switch termProgram {
+        case .some("apple_terminal"): return "Terminal"
+        case .some("iterm.app"), .some("iterm2"): return "iTerm"
+        case let value? where value.contains("ghostty"): return "Ghostty"
+        case let value? where value.contains("warp"): return "Warp"
+        case let value? where value.contains("wezterm"): return "WezTerm"
+        case .some("kaku"): return "Kaku"
+        case .some("vscode"): return "VS Code"
+        case .some("vscode-insiders"): return "VS Code Insiders"
+        case .some("windsurf"): return "Windsurf"
+        case .some("trae"): return "Trae"
+        default: break
+        }
+
+        if let terminalEmulator = environment["TERMINAL_EMULATOR"]?.lowercased(),
+           terminalEmulator.contains("jetbrains") {
+            if let bundleID = environment["__CFBundleIdentifier"]?.lowercased() {
+                if bundleID.contains("webstorm") { return "WebStorm" }
+                if bundleID.contains("pycharm") { return "PyCharm" }
+                if bundleID.contains("goland") { return "GoLand" }
+                if bundleID.contains("clion") { return "CLion" }
+                if bundleID.contains("rubymine") { return "RubyMine" }
+                if bundleID.contains("phpstorm") { return "PhpStorm" }
+                if bundleID.contains("rider") { return "Rider" }
+                if bundleID.contains("rustrover") { return "RustRover" }
+                if bundleID.contains("intellij") { return "IntelliJ IDEA" }
+            }
+            return "IntelliJ IDEA"
+        }
+
+        return nil
+    }
+
+    private func currentTTY() -> String? {
+        if let tty = commandOutput(executablePath: "/usr/bin/tty", arguments: []),
+           !tty.contains("not a tty") {
+            return tty
+        }
+        return parentProcessTTY()
+    }
+
+    private func parentProcessTTY() -> String? {
+        let ppid = getppid()
+        guard let raw = commandOutput(executablePath: "/bin/ps", arguments: ["-p", "\(ppid)", "-o", "tty="]) else {
+            return nil
+        }
+        let tty = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tty.isEmpty, tty != "??", tty != "-" else { return nil }
+        return tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+    }
+
+    private func terminalLocator(for terminalApp: String) -> (sessionID: String?, tty: String?, title: String?) {
+        let normalized = terminalApp.lowercased()
+
+        if normalized.contains("iterm") {
+            let values = osascriptValues(script: """
+            tell application "iTerm"
+                if not (it is running) then return ""
+                tell current session of current window
+                    return (id as text) & (ASCII character 31) & (tty as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: values[safe: 0], tty: values[safe: 1], title: values[safe: 2])
+        }
+
+        if normalized.contains("ghostty") {
+            let values = osascriptValues(script: """
+            tell application "Ghostty"
+                if not (it is running) then return ""
+                tell focused terminal of selected tab of front window
+                    return (id as text) & (ASCII character 31) & (working directory as text) & (ASCII character 31) & (name as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: values[safe: 0], tty: nil, title: values[safe: 2])
+        }
+
+        if normalized.contains("terminal") {
+            let values = osascriptValues(script: """
+            tell application "Terminal"
+                if not (it is running) then return ""
+                tell selected tab of front window
+                    return (tty as text) & (ASCII character 31) & (custom title as text)
+                end tell
+            end tell
+            """)
+            return (sessionID: nil, tty: values[safe: 0], title: values[safe: 1])
+        }
+
+        return (nil, nil, nil)
+    }
+
+    private func osascriptValues(script: String) -> [String] {
+        guard let raw = commandOutput(executablePath: "/usr/bin/osascript", arguments: ["-e", script]) else {
+            return []
+        }
+        let separator = String(UnicodeScalar(31)!)
+        return raw
+            .components(separatedBy: separator)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private func commandOutput(executablePath: String, arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty else { return nil }
+        return output
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+// MARK: - Workspace Name Resolver
+
+enum CodexWorkspaceNameResolver {
+    private static let worktreeMarkers = ["/.claude/worktrees/", "/.git/worktrees/"]
+
+    static func workspaceName(for cwd: String) -> String {
+        let path = URL(fileURLWithPath: cwd).standardizedFileURL.path
+        for marker in worktreeMarkers {
+            if let range = path.range(of: marker) {
+                let projectName = URL(fileURLWithPath: String(path[path.startIndex ..< range.lowerBound])).lastPathComponent
+                if !projectName.isEmpty { return projectName }
+            }
+        }
+        let name = URL(fileURLWithPath: cwd).lastPathComponent
+        return name.isEmpty ? "Workspace" : name
+    }
+
+    static func worktreeBranch(for cwd: String) -> String? {
+        let path = URL(fileURLWithPath: cwd).standardizedFileURL.path
+        for marker in worktreeMarkers {
+            guard let range = path.range(of: marker) else { continue }
+            let branch = String(path[range.upperBound...])
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                .replacingOccurrences(of: "+", with: "/")
+            return branch.isEmpty ? nil : branch
+        }
+        return nil
+    }
+}

--- a/ClaudeIsland/Services/Session/CodexSessionTracking.swift
+++ b/ClaudeIsland/Services/Session/CodexSessionTracking.swift
@@ -1,0 +1,875 @@
+//
+//  CodexSessionTracking.swift
+//  ClaudeIsland
+//
+//  Session persistence, rollout file discovery, and live file watching for Codex sessions.
+//  Reads ~/.codex/sessions/rollout-*.jsonl to discover and track active Codex sessions.
+//
+
+import Dispatch
+import Foundation
+
+// MARK: - Codex-Specific Session Types
+
+/// Simple session phase for Codex rollout tracking (distinct from Claude's SessionPhase).
+enum CodexSessionPhase: String, Codable, Sendable {
+    case running
+    case waitingForApproval
+    case waitingForAnswer
+    case completed
+}
+
+enum CodexSessionOrigin: String, Codable, Sendable {
+    case live
+    case demo
+}
+
+enum CodexSessionAttachmentState: String, Codable, Sendable {
+    case attached
+    case stale
+    case detached
+
+    var isLive: Bool { self == .attached }
+}
+
+struct CodexJumpTarget: Equatable, Codable, Sendable {
+    var terminalApp: String
+    var workspaceName: String
+    var paneTitle: String
+    var workingDirectory: String?
+    var terminalSessionID: String?
+    var terminalTTY: String?
+}
+
+// MARK: - Session Metadata
+
+struct CodexSessionMetadata: Equatable, Codable, Sendable {
+    var transcriptPath: String?
+    var initialUserPrompt: String?
+    var lastUserPrompt: String?
+    var lastAssistantMessage: String?
+    var currentTool: String?
+    var currentCommandPreview: String?
+
+    init(
+        transcriptPath: String? = nil,
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        currentTool: String? = nil,
+        currentCommandPreview: String? = nil
+    ) {
+        self.transcriptPath = transcriptPath
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.currentTool = currentTool
+        self.currentCommandPreview = currentCommandPreview
+    }
+
+    var isEmpty: Bool {
+        transcriptPath == nil
+            && initialUserPrompt == nil
+            && lastUserPrompt == nil
+            && lastAssistantMessage == nil
+            && currentTool == nil
+            && currentCommandPreview == nil
+    }
+}
+
+// MARK: - Tracked Session Record
+
+struct CodexTrackedSessionRecord: Equatable, Codable, Sendable {
+    var sessionID: String
+    var title: String
+    var origin: CodexSessionOrigin?
+    var attachmentState: CodexSessionAttachmentState
+    var summary: String
+    var phase: CodexSessionPhase
+    var updatedAt: Date
+    var jumpTarget: CodexJumpTarget?
+    var codexMetadata: CodexSessionMetadata?
+
+    init(
+        sessionID: String,
+        title: String,
+        origin: CodexSessionOrigin? = nil,
+        attachmentState: CodexSessionAttachmentState = .stale,
+        summary: String,
+        phase: CodexSessionPhase,
+        updatedAt: Date,
+        jumpTarget: CodexJumpTarget? = nil,
+        codexMetadata: CodexSessionMetadata? = nil
+    ) {
+        self.sessionID = sessionID
+        self.title = title
+        self.origin = origin
+        self.attachmentState = attachmentState
+        self.summary = summary
+        self.phase = phase
+        self.updatedAt = updatedAt
+        self.jumpTarget = jumpTarget
+        self.codexMetadata = codexMetadata
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID, title, origin, attachmentState, summary, phase, updatedAt, jumpTarget, codexMetadata
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionID = try container.decode(String.self, forKey: .sessionID)
+        title = try container.decode(String.self, forKey: .title)
+        origin = try container.decodeIfPresent(CodexSessionOrigin.self, forKey: .origin)
+        attachmentState = try container.decodeIfPresent(CodexSessionAttachmentState.self, forKey: .attachmentState) ?? .stale
+        summary = try container.decode(String.self, forKey: .summary)
+        phase = try container.decode(CodexSessionPhase.self, forKey: .phase)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        jumpTarget = try container.decodeIfPresent(CodexJumpTarget.self, forKey: .jumpTarget)
+        codexMetadata = try container.decodeIfPresent(CodexSessionMetadata.self, forKey: .codexMetadata)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(title, forKey: .title)
+        try container.encodeIfPresent(origin, forKey: .origin)
+        try container.encode(attachmentState, forKey: .attachmentState)
+        try container.encode(summary, forKey: .summary)
+        try container.encode(phase, forKey: .phase)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(jumpTarget, forKey: .jumpTarget)
+        try container.encodeIfPresent(codexMetadata, forKey: .codexMetadata)
+    }
+}
+
+extension CodexTrackedSessionRecord {
+    var shouldRestoreToLiveState: Bool {
+        origin != .demo
+    }
+}
+
+// MARK: - Session Store
+
+final class CodexSessionStore: @unchecked Sendable {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    static var defaultDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/CodeIsland", isDirectory: true)
+    }
+
+    static var defaultFileURL: URL {
+        defaultDirectoryURL.appendingPathComponent("codex-sessions.json")
+    }
+
+    init(fileURL: URL = CodexSessionStore.defaultFileURL, fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [CodexTrackedSessionRecord] {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([CodexTrackedSessionRecord].self, from: data)
+    }
+
+    func save(_ records: [CodexTrackedSessionRecord]) throws {
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(records).write(to: fileURL, options: .atomic)
+    }
+}
+
+// MARK: - Rollout Discovery
+
+final class CodexRolloutDiscovery: @unchecked Sendable {
+    private struct Candidate {
+        var fileURL: URL
+        var modifiedAt: Date
+    }
+
+    private struct SessionMeta {
+        var sessionID: String
+        var cwd: String
+        var timestamp: Date?
+
+        var workspaceName: String {
+            let name = URL(fileURLWithPath: cwd).lastPathComponent
+            return name.isEmpty ? "Workspace" : name
+        }
+
+        var sessionTitle: String { "Codex · \(workspaceName)" }
+        var defaultSummary: String { "Started Codex session in \(workspaceName)." }
+    }
+
+    static var defaultRootURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/sessions", isDirectory: true)
+    }
+
+    private let rootURL: URL
+    private let fileManager: FileManager
+    private let maxAge: TimeInterval
+    private let maxFiles: Int
+
+    init(
+        rootURL: URL = CodexRolloutDiscovery.defaultRootURL,
+        fileManager: FileManager = .default,
+        maxAge: TimeInterval = 86_400,
+        maxFiles: Int = 40
+    ) {
+        self.rootURL = rootURL
+        self.fileManager = fileManager
+        self.maxAge = maxAge
+        self.maxFiles = maxFiles
+    }
+
+    func discoverRecentSessions(now: Date = .now) -> [CodexTrackedSessionRecord] {
+        guard fileManager.fileExists(atPath: rootURL.path),
+              let enumerator = fileManager.enumerator(
+                at: rootURL,
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
+              ) else { return [] }
+
+        let cutoff = now.addingTimeInterval(-maxAge)
+        var candidates: [Candidate] = []
+
+        for case let fileURL as URL in enumerator {
+            guard fileURL.lastPathComponent.hasPrefix("rollout-"),
+                  fileURL.pathExtension == "jsonl",
+                  let resourceValues = try? fileURL.resourceValues(
+                    forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                  ),
+                  resourceValues.isRegularFile == true else { continue }
+
+            let modifiedAt = resourceValues.contentModificationDate ?? .distantPast
+            guard modifiedAt >= cutoff else { continue }
+            candidates.append(Candidate(fileURL: fileURL, modifiedAt: modifiedAt))
+        }
+
+        let recentCandidates = candidates
+            .sorted { lhs, rhs in
+                lhs.modifiedAt == rhs.modifiedAt
+                    ? lhs.fileURL.lastPathComponent.localizedStandardCompare(rhs.fileURL.lastPathComponent) == .orderedDescending
+                    : lhs.modifiedAt > rhs.modifiedAt
+            }
+            .prefix(maxFiles)
+
+        var recordsByID: [String: CodexTrackedSessionRecord] = [:]
+        for candidate in recentCandidates {
+            guard let record = discoverRecord(fileURL: candidate.fileURL, modifiedAt: candidate.modifiedAt) else { continue }
+            if let existing = recordsByID[record.sessionID], existing.updatedAt >= record.updatedAt { continue }
+            recordsByID[record.sessionID] = record
+        }
+
+        return recordsByID.values.sorted { lhs, rhs in
+            lhs.updatedAt == rhs.updatedAt
+                ? lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
+                : lhs.updatedAt > rhs.updatedAt
+        }
+    }
+
+    private func discoverRecord(fileURL: URL, modifiedAt: Date) -> CodexTrackedSessionRecord? {
+        guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        let lines = contents.split(whereSeparator: \.isNewline).map(String.init)
+        guard !lines.isEmpty, let sessionMeta = sessionMeta(from: lines) else { return nil }
+
+        let snapshot = CodexRolloutReducer.snapshot(for: lines)
+        let summary = snapshot.summary ?? sessionMeta.defaultSummary
+        let updatedAt = snapshot.updatedAt ?? sessionMeta.timestamp ?? modifiedAt
+        let metadata = CodexSessionMetadata(
+            transcriptPath: fileURL.path,
+            initialUserPrompt: snapshot.initialUserPrompt,
+            lastUserPrompt: snapshot.lastUserPrompt,
+            lastAssistantMessage: snapshot.lastAssistantMessage,
+            currentTool: snapshot.currentTool,
+            currentCommandPreview: snapshot.currentCommandPreview
+        )
+
+        return CodexTrackedSessionRecord(
+            sessionID: sessionMeta.sessionID,
+            title: sessionMeta.sessionTitle,
+            origin: .live,
+            attachmentState: .stale,
+            summary: summary,
+            phase: snapshot.phase,
+            updatedAt: updatedAt,
+            codexMetadata: metadata
+        )
+    }
+
+    private func sessionMeta(from lines: [String]) -> SessionMeta? {
+        for line in lines {
+            guard let object = codexRolloutJSONObject(for: line),
+                  object["type"] as? String == "session_meta" else { continue }
+            let payload = object["payload"] as? [String: Any] ?? [:]
+            guard let sessionID = payload["id"] as? String, !sessionID.isEmpty,
+                  let cwd = payload["cwd"] as? String, !cwd.isEmpty else { continue }
+            return SessionMeta(
+                sessionID: sessionID,
+                cwd: cwd,
+                timestamp: codexRolloutParseTimestamp(
+                    (payload["timestamp"] as? String) ?? (object["timestamp"] as? String)
+                )
+            )
+        }
+        return nil
+    }
+}
+
+// MARK: - Rollout Watch Target & Events
+
+struct CodexRolloutWatchTarget: Equatable, Sendable {
+    var sessionID: String
+    var transcriptPath: String
+}
+
+/// Events emitted by `CodexRolloutWatcher` as rollout files change.
+enum CodexRolloutEvent: Sendable {
+    case metadataUpdated(sessionID: String, metadata: CodexSessionMetadata, timestamp: Date)
+    case activityUpdated(sessionID: String, summary: String, phase: CodexSessionPhase, timestamp: Date)
+    case sessionCompleted(sessionID: String, summary: String, isInterrupt: Bool, timestamp: Date)
+}
+
+// MARK: - Rollout Snapshot
+
+struct CodexRolloutSnapshot: Equatable, Sendable {
+    var summary: String?
+    var phase: CodexSessionPhase
+    var updatedAt: Date?
+    var initialUserPrompt: String?
+    var lastUserPrompt: String?
+    var lastAssistantMessage: String?
+    var currentTool: String?
+    var currentCommandPreview: String?
+    var isCompleted: Bool
+    var isInterrupted: Bool
+
+    init(
+        summary: String? = nil,
+        phase: CodexSessionPhase = .running,
+        updatedAt: Date? = nil,
+        initialUserPrompt: String? = nil,
+        lastUserPrompt: String? = nil,
+        lastAssistantMessage: String? = nil,
+        currentTool: String? = nil,
+        currentCommandPreview: String? = nil,
+        isCompleted: Bool = false,
+        isInterrupted: Bool = false
+    ) {
+        self.summary = summary
+        self.phase = phase
+        self.updatedAt = updatedAt
+        self.initialUserPrompt = initialUserPrompt
+        self.lastUserPrompt = lastUserPrompt
+        self.lastAssistantMessage = lastAssistantMessage
+        self.currentTool = currentTool
+        self.currentCommandPreview = currentCommandPreview
+        self.isCompleted = isCompleted
+        self.isInterrupted = isInterrupted
+    }
+
+    var metadata: CodexSessionMetadata {
+        CodexSessionMetadata(
+            initialUserPrompt: initialUserPrompt,
+            lastUserPrompt: lastUserPrompt,
+            lastAssistantMessage: lastAssistantMessage,
+            currentTool: currentTool,
+            currentCommandPreview: currentCommandPreview
+        )
+    }
+}
+
+// MARK: - Rollout Reducer
+
+enum CodexRolloutReducer {
+    static func snapshot(for lines: [String]) -> CodexRolloutSnapshot {
+        var snapshot = CodexRolloutSnapshot()
+        lines.forEach { apply(line: $0, to: &snapshot) }
+        return snapshot
+    }
+
+    static func apply(line: String, to snapshot: inout CodexRolloutSnapshot) {
+        guard let object = jsonObject(for: line) else { return }
+        let timestamp = parseTimestamp(object["timestamp"] as? String)
+        let payload = object["payload"] as? [String: Any] ?? [:]
+
+        switch object["type"] as? String {
+        case "event_msg": applyEventMessage(payload, timestamp: timestamp, to: &snapshot)
+        case "response_item": applyResponseItem(payload, timestamp: timestamp, to: &snapshot)
+        default: break
+        }
+    }
+
+    static func events(
+        from oldSnapshot: CodexRolloutSnapshot?,
+        to newSnapshot: CodexRolloutSnapshot,
+        sessionID: String,
+        transcriptPath: String
+    ) -> [CodexRolloutEvent] {
+        var events: [CodexRolloutEvent] = []
+        let timestamp = newSnapshot.updatedAt ?? .now
+
+        let oldMetadata = oldSnapshot.map {
+            CodexSessionMetadata(
+                transcriptPath: transcriptPath,
+                initialUserPrompt: $0.initialUserPrompt,
+                lastUserPrompt: $0.lastUserPrompt,
+                lastAssistantMessage: $0.lastAssistantMessage,
+                currentTool: $0.currentTool,
+                currentCommandPreview: $0.currentCommandPreview
+            )
+        }
+        let newMetadata = CodexSessionMetadata(
+            transcriptPath: transcriptPath,
+            initialUserPrompt: newSnapshot.initialUserPrompt,
+            lastUserPrompt: newSnapshot.lastUserPrompt,
+            lastAssistantMessage: newSnapshot.lastAssistantMessage,
+            currentTool: newSnapshot.currentTool,
+            currentCommandPreview: newSnapshot.currentCommandPreview
+        )
+
+        if oldMetadata != newMetadata {
+            events.append(.metadataUpdated(sessionID: sessionID, metadata: newMetadata, timestamp: timestamp))
+        }
+
+        let oldSummary = oldSnapshot?.summary
+        let oldPhase = oldSnapshot?.phase
+        let oldCompleted = oldSnapshot?.isCompleted ?? false
+        let oldInterrupted = oldSnapshot?.isInterrupted ?? false
+        let newSummary = newSnapshot.summary ?? oldSummary ?? "Codex updated the current turn."
+
+        if newSnapshot.isCompleted {
+            if !oldCompleted || oldSummary != newSummary || oldInterrupted != newSnapshot.isInterrupted {
+                events.append(.sessionCompleted(
+                    sessionID: sessionID,
+                    summary: newSummary,
+                    isInterrupt: newSnapshot.isInterrupted,
+                    timestamp: timestamp
+                ))
+            }
+        } else if oldSummary != newSummary || oldPhase != newSnapshot.phase {
+            events.append(.activityUpdated(
+                sessionID: sessionID,
+                summary: newSummary,
+                phase: newSnapshot.phase,
+                timestamp: timestamp
+            ))
+        }
+
+        return events
+    }
+
+    private static func applyEventMessage(
+        _ payload: [String: Any],
+        timestamp: Date?,
+        to snapshot: inout CodexRolloutSnapshot
+    ) {
+        switch payload["type"] as? String {
+        case "task_started":
+            snapshot.phase = .running
+            snapshot.isCompleted = false
+            snapshot.isInterrupted = false
+            snapshot.summary = snapshot.summary ?? "Codex started a new turn."
+        case "user_message":
+            guard let message = clipped(payload["message"] as? String), !message.isEmpty else { break }
+            applyUserMessage(message, timestamp: timestamp, to: &snapshot)
+            return
+        case "agent_message":
+            guard let message = clipped(payload["message"] as? String), !message.isEmpty else { break }
+            applyAssistantMessage(message, timestamp: timestamp, to: &snapshot)
+            return
+        case "task_complete":
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            snapshot.phase = .completed
+            snapshot.isCompleted = true
+            snapshot.isInterrupted = false
+            if let message = payload["last_agent_message"] as? String, !message.isEmpty {
+                snapshot.lastAssistantMessage = message
+                snapshot.summary = message
+            } else {
+                snapshot.summary = snapshot.summary ?? "Codex completed the turn."
+            }
+        case "turn_aborted":
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            snapshot.phase = .completed
+            snapshot.isCompleted = true
+            snapshot.isInterrupted = true
+            snapshot.summary = "Codex turn was interrupted."
+        case "exec_command_end":
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            if !snapshot.isCompleted { snapshot.phase = .running }
+            snapshot.summary = "Command finished."
+        case "patch_apply_end":
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            if !snapshot.isCompleted { snapshot.phase = .running }
+            snapshot.summary = "Patch applied."
+        default:
+            break
+        }
+        if let timestamp { snapshot.updatedAt = timestamp }
+    }
+
+    private static func applyResponseItem(
+        _ payload: [String: Any],
+        timestamp: Date?,
+        to snapshot: inout CodexRolloutSnapshot
+    ) {
+        let itemType = payload["type"] as? String
+        if itemType == "message" {
+            guard let role = payload["role"] as? String else { return }
+            switch role {
+            case "user":
+                guard let message = responseMessageText(from: payload, textType: "input_text", skipsInjectedBlocks: true) else { return }
+                applyUserMessage(message, timestamp: timestamp, to: &snapshot)
+            case "assistant":
+                guard let message = responseMessageText(from: payload, textType: "output_text", skipsInjectedBlocks: false) else { return }
+                applyAssistantMessage(message, timestamp: timestamp, to: &snapshot)
+            default: return
+            }
+            return
+        }
+
+        guard itemType == "function_call" || itemType == "custom_tool_call" else { return }
+        guard let toolName = payload["name"] as? String, !toolName.isEmpty else { return }
+        guard !snapshot.isCompleted else {
+            if let timestamp { snapshot.updatedAt = timestamp }
+            return
+        }
+
+        snapshot.currentTool = toolName
+        snapshot.currentCommandPreview = commandPreview(for: toolName, payload: payload)
+        snapshot.phase = .running
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = "Running \(displayName(for: toolName))."
+        if let timestamp { snapshot.updatedAt = timestamp }
+    }
+
+    private static func applyUserMessage(_ message: String, timestamp: Date?, to snapshot: inout CodexRolloutSnapshot) {
+        snapshot.initialUserPrompt = snapshot.initialUserPrompt ?? message
+        snapshot.lastUserPrompt = message
+        snapshot.currentTool = nil
+        snapshot.currentCommandPreview = nil
+        snapshot.phase = .running
+        snapshot.isCompleted = false
+        snapshot.isInterrupted = false
+        snapshot.summary = "Prompt: \(message)"
+        if let timestamp { snapshot.updatedAt = timestamp }
+    }
+
+    private static func applyAssistantMessage(_ message: String, timestamp: Date?, to snapshot: inout CodexRolloutSnapshot) {
+        snapshot.lastAssistantMessage = message
+        snapshot.summary = message
+        if !snapshot.isCompleted {
+            snapshot.currentTool = nil
+            snapshot.currentCommandPreview = nil
+            snapshot.phase = .running
+            snapshot.isInterrupted = false
+        }
+        if let timestamp { snapshot.updatedAt = timestamp }
+    }
+
+    private static func displayName(for toolName: String) -> String {
+        switch toolName {
+        case "exec_command": "command"
+        case "apply_patch": "patch"
+        case "write_stdin": "input"
+        default: toolName
+        }
+    }
+
+    private static func commandPreview(for toolName: String, payload: [String: Any]) -> String? {
+        guard let arguments = payload["arguments"] as? String,
+              let data = arguments.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        switch toolName {
+        case "exec_command": return clipped(object["cmd"] as? String)
+        case "write_stdin": return clipped(object["chars"] as? String)
+        default: return nil
+        }
+    }
+
+    private static func responseMessageText(
+        from payload: [String: Any],
+        textType: String,
+        skipsInjectedBlocks: Bool
+    ) -> String? {
+        guard let content = payload["content"] as? [[String: Any]] else { return nil }
+        let segments = content.compactMap { item -> String? in
+            guard item["type"] as? String == textType,
+                  let text = item["text"] as? String else { return nil }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if skipsInjectedBlocks, isInjectedPromptBlock(trimmed) { return nil }
+            return trimmed
+        }
+        guard !segments.isEmpty else { return nil }
+        return clipped(segments.joined(separator: " "))
+    }
+
+    private static func isInjectedPromptBlock(_ text: String) -> Bool {
+        text.hasPrefix("# AGENTS.md instructions for ")
+            || text.hasPrefix("<environment_context>")
+            || text.hasPrefix("<permissions instructions>")
+            || text.hasPrefix("<collaboration_mode>")
+            || text.hasPrefix("<skills_instructions>")
+    }
+
+    private static func clipped(_ value: String?, limit: Int = 110) -> String? {
+        guard let value else { return nil }
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > limit else { return collapsed }
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: limit - 1)
+        return "\(collapsed[..<endIndex])…"
+    }
+
+    private static func jsonObject(for line: String) -> [String: Any]? {
+        codexRolloutJSONObject(for: line)
+    }
+
+    private static func parseTimestamp(_ string: String?) -> Date? {
+        codexRolloutParseTimestamp(string)
+    }
+}
+
+// MARK: - Rollout Watcher
+
+final class CodexRolloutWatcher: @unchecked Sendable {
+    private struct Observation {
+        var target: CodexRolloutWatchTarget
+        var offset: UInt64 = 0
+        var pendingBuffer = Data()
+        var snapshot = CodexRolloutSnapshot()
+        var shouldTrimLeadingPartialLine = false
+    }
+
+    var eventHandler: (@Sendable (CodexRolloutEvent) -> Void)?
+
+    private let pollInterval: TimeInterval
+    private let initialReadLimit: UInt64
+    private let initialPromptBootstrapLimit: UInt64
+    private let queue = DispatchQueue(label: "com.codeisland.codex.rollout-watcher")
+    private var timer: DispatchSourceTimer?
+    private var observations: [String: Observation] = [:]
+
+    init(
+        pollInterval: TimeInterval = 3.0,
+        initialReadLimit: UInt64 = 128 * 1_024,
+        initialPromptBootstrapLimit: UInt64 = 4 * 1_024 * 1_024
+    ) {
+        self.pollInterval = pollInterval
+        self.initialReadLimit = initialReadLimit
+        self.initialPromptBootstrapLimit = initialPromptBootstrapLimit
+    }
+
+    deinit { stop() }
+
+    func sync(targets: [CodexRolloutWatchTarget]) {
+        queue.sync { syncLocked(targets: targets) }
+    }
+
+    func stop() {
+        queue.sync {
+            timer?.cancel()
+            timer = nil
+            observations.removeAll()
+        }
+    }
+
+    private func syncLocked(targets: [CodexRolloutWatchTarget]) {
+        let targetMap = Dictionary(uniqueKeysWithValues: targets.map { ($0.sessionID, $0) })
+
+        observations = observations.reduce(into: [:]) { result, pair in
+            guard let updatedTarget = targetMap[pair.key] else { return }
+            result[pair.key] = pair.value.target == updatedTarget
+                ? pair.value
+                : makeObservation(for: updatedTarget)
+        }
+
+        for target in targets where observations[target.sessionID] == nil {
+            observations[target.sessionID] = makeObservation(for: target)
+        }
+
+        if observations.isEmpty {
+            timer?.cancel()
+            timer = nil
+            return
+        }
+
+        if timer == nil {
+            let timer = DispatchSource.makeTimerSource(queue: queue)
+            timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
+            timer.setEventHandler { [weak self] in self?.pollLocked() }
+            self.timer = timer
+            timer.resume()
+        }
+
+        pollLocked()
+    }
+
+    private func pollLocked() {
+        for sessionID in Array(observations.keys) {
+            guard var observation = observations[sessionID] else { continue }
+            let events = refresh(observation: &observation)
+            observations[sessionID] = observation
+            events.forEach { eventHandler?($0) }
+        }
+    }
+
+    private func refresh(observation: inout Observation) -> [CodexRolloutEvent] {
+        let fileURL = URL(fileURLWithPath: observation.target.transcriptPath)
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let fileHandle = try? FileHandle(forReadingFrom: fileURL) else { return [] }
+        defer { try? fileHandle.close() }
+
+        let fileSize = (try? fileHandle.seekToEnd()) ?? 0
+        if fileSize < observation.offset {
+            observation.offset = 0
+            observation.pendingBuffer.removeAll(keepingCapacity: false)
+            observation.snapshot = CodexRolloutSnapshot()
+        }
+
+        do {
+            try fileHandle.seek(toOffset: observation.offset)
+            let data = try fileHandle.readToEnd() ?? Data()
+            guard !data.isEmpty else { return [] }
+
+            observation.offset += UInt64(data.count)
+            observation.pendingBuffer.append(data)
+
+            if observation.shouldTrimLeadingPartialLine {
+                trimLeadingPartialLine(from: &observation.pendingBuffer)
+                observation.shouldTrimLeadingPartialLine = false
+            }
+
+            let lines = completeLines(from: &observation.pendingBuffer)
+            guard !lines.isEmpty else { return [] }
+
+            let oldSnapshot = observation.snapshot
+            lines.forEach { CodexRolloutReducer.apply(line: $0, to: &observation.snapshot) }
+
+            return CodexRolloutReducer.events(
+                from: oldSnapshot,
+                to: observation.snapshot,
+                sessionID: observation.target.sessionID,
+                transcriptPath: observation.target.transcriptPath
+            )
+        } catch {
+            return []
+        }
+    }
+
+    private func completeLines(from buffer: inout Data) -> [String] {
+        let newline = UInt8(ascii: "\n")
+        var lines: [String] = []
+        while let newlineIndex = buffer.firstIndex(of: newline) {
+            let lineData = buffer.prefix(upTo: newlineIndex)
+            buffer.removeSubrange(...newlineIndex)
+            guard !lineData.isEmpty else { continue }
+            lines.append(String(decoding: lineData, as: UTF8.self))
+        }
+        return lines
+    }
+
+    private func makeObservation(for target: CodexRolloutWatchTarget) -> Observation {
+        let fileURL = URL(fileURLWithPath: target.transcriptPath)
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
+            return Observation(target: target)
+        }
+        defer { try? fileHandle.close() }
+
+        let fileSize = (try? fileHandle.seekToEnd()) ?? 0
+        guard fileSize > initialReadLimit else { return Observation(target: target) }
+
+        let bootstrapSnapshot = bootstrapPromptSnapshot(fileHandle: fileHandle, fileSize: fileSize)
+        return Observation(
+            target: target,
+            offset: fileSize - initialReadLimit,
+            pendingBuffer: Data(),
+            snapshot: bootstrapSnapshot,
+            shouldTrimLeadingPartialLine: true
+        )
+    }
+
+    private func bootstrapPromptSnapshot(fileHandle: FileHandle, fileSize: UInt64) -> CodexRolloutSnapshot {
+        let readLimit = min(fileSize, initialPromptBootstrapLimit)
+        guard readLimit > 0 else { return CodexRolloutSnapshot() }
+        let initialPrompt = bootstrapInitialPrompt(fileHandle: fileHandle, readLimit: readLimit)
+        let lastPrompt = bootstrapLastPrompt(fileHandle: fileHandle, fileSize: fileSize, readLimit: readLimit)
+        return CodexRolloutSnapshot(initialUserPrompt: initialPrompt, lastUserPrompt: lastPrompt ?? initialPrompt)
+    }
+
+    private func bootstrapInitialPrompt(fileHandle: FileHandle, readLimit: UInt64) -> String? {
+        do {
+            try fileHandle.seek(toOffset: 0)
+            var buffer = Data()
+            var snapshot = CodexRolloutSnapshot()
+            var bytesRemaining = readLimit
+            while bytesRemaining > 0, snapshot.initialUserPrompt == nil {
+                let chunkSize = Int(min(bytesRemaining, 64 * 1_024))
+                guard let data = try fileHandle.read(upToCount: chunkSize), !data.isEmpty else { break }
+                buffer.append(data)
+                bytesRemaining -= UInt64(data.count)
+                let lines = completeLines(from: &buffer)
+                guard !lines.isEmpty else { continue }
+                lines.forEach { CodexRolloutReducer.apply(line: $0, to: &snapshot) }
+            }
+            return snapshot.initialUserPrompt
+        } catch { return nil }
+    }
+
+    private func bootstrapLastPrompt(fileHandle: FileHandle, fileSize: UInt64, readLimit: UInt64) -> String? {
+        do {
+            let startOffset = fileSize > readLimit ? fileSize - readLimit : 0
+            try fileHandle.seek(toOffset: startOffset)
+            var buffer = try fileHandle.readToEnd() ?? Data()
+            guard !buffer.isEmpty else { return nil }
+            if startOffset > 0 { trimLeadingPartialLine(from: &buffer) }
+            return CodexRolloutReducer.snapshot(for: completeLines(from: &buffer)).lastUserPrompt
+        } catch { return nil }
+    }
+
+    private func trimLeadingPartialLine(from buffer: inout Data) {
+        let newline = UInt8(ascii: "\n")
+        guard let newlineIndex = buffer.firstIndex(of: newline) else {
+            buffer.removeAll(keepingCapacity: false)
+            return
+        }
+        buffer.removeSubrange(...newlineIndex)
+    }
+}
+
+// MARK: - Private Helpers
+
+private func codexRolloutJSONObject(for line: String) -> [String: Any]? {
+    guard let data = line.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data),
+          let dictionary = object as? [String: Any] else { return nil }
+    return dictionary
+}
+
+private func codexRolloutParseTimestamp(_ string: String?) -> Date? {
+    guard let string else { return nil }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.date(from: string)
+}

--- a/ClaudeIsland/Services/Session/CodexUsage.swift
+++ b/ClaudeIsland/Services/Session/CodexUsage.swift
@@ -1,0 +1,193 @@
+//
+//  CodexUsage.swift
+//  ClaudeIsland
+//
+//  Reads rate-limit / usage data from Codex rollout JSONL files.
+//  Scans ~/.codex/sessions/rollout-*.jsonl for the most recent token_count event.
+//
+
+import Foundation
+
+struct CodexUsageWindow: Equatable, Codable, Sendable, Identifiable {
+    var key: String
+    var label: String
+    var usedPercentage: Double
+    var leftPercentage: Double
+    var windowMinutes: Int
+    var resetsAt: Date?
+
+    var id: String { key }
+
+    var roundedUsedPercentage: Int {
+        Int(usedPercentage.rounded())
+    }
+}
+
+struct CodexUsageSnapshot: Equatable, Codable, Sendable {
+    var sourceFilePath: String
+    var capturedAt: Date?
+    var planType: String?
+    var limitID: String?
+    var windows: [CodexUsageWindow]
+
+    var isEmpty: Bool { windows.isEmpty }
+}
+
+enum CodexUsageLoader {
+    static let defaultRootURL = CodexRolloutDiscovery.defaultRootURL
+
+    private struct Candidate {
+        var fileURL: URL
+        var modifiedAt: Date
+    }
+
+    static func load(
+        fromRootURL rootURL: URL = defaultRootURL,
+        fileManager: FileManager = .default
+    ) throws -> CodexUsageSnapshot? {
+        guard fileManager.fileExists(atPath: rootURL.path),
+              let enumerator = fileManager.enumerator(
+                at: rootURL,
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
+              ) else { return nil }
+
+        var candidates: [Candidate] = []
+        for case let fileURL as URL in enumerator {
+            guard fileURL.lastPathComponent.hasPrefix("rollout-"),
+                  fileURL.pathExtension == "jsonl",
+                  let resourceValues = try? fileURL.resourceValues(
+                    forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                  ),
+                  resourceValues.isRegularFile == true else { continue }
+            candidates.append(Candidate(
+                fileURL: fileURL,
+                modifiedAt: resourceValues.contentModificationDate ?? .distantPast
+            ))
+        }
+
+        let sortedCandidates = candidates.sorted { lhs, rhs in
+            lhs.modifiedAt == rhs.modifiedAt
+                ? lhs.fileURL.path.localizedStandardCompare(rhs.fileURL.path) == .orderedDescending
+                : lhs.modifiedAt > rhs.modifiedAt
+        }
+
+        for candidate in sortedCandidates {
+            if let snapshot = loadLatestSnapshot(from: candidate.fileURL, modifiedAt: candidate.modifiedAt) {
+                return snapshot
+            }
+        }
+
+        return nil
+    }
+
+    private static func loadLatestSnapshot(from fileURL: URL, modifiedAt: Date) -> CodexUsageSnapshot? {
+        guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        var latestSnapshot: CodexUsageSnapshot?
+        contents.enumerateLines { line, _ in
+            guard let snapshot = snapshot(from: line, filePath: fileURL.path, fallbackTimestamp: modifiedAt) else {
+                return
+            }
+            latestSnapshot = snapshot
+        }
+        return latestSnapshot
+    }
+
+    private static func snapshot(from line: String, filePath: String, fallbackTimestamp: Date) -> CodexUsageSnapshot? {
+        guard let object = jsonObject(for: line),
+              object["type"] as? String == "event_msg" else { return nil }
+
+        let payload = object["payload"] as? [String: Any] ?? [:]
+        guard payload["type"] as? String == "token_count",
+              let rateLimits = payload["rate_limits"] as? [String: Any] else { return nil }
+
+        let windows = ["primary", "secondary"].compactMap { key in
+            usageWindow(for: key, in: rateLimits)
+        }
+        guard !windows.isEmpty else { return nil }
+
+        return CodexUsageSnapshot(
+            sourceFilePath: filePath,
+            capturedAt: timestamp(from: object["timestamp"]) ?? fallbackTimestamp,
+            planType: string(from: rateLimits["plan_type"]),
+            limitID: string(from: rateLimits["limit_id"]),
+            windows: windows
+        )
+    }
+
+    private static func usageWindow(for key: String, in rateLimits: [String: Any]) -> CodexUsageWindow? {
+        guard let payload = rateLimits[key] as? [String: Any],
+              let usedPercentage = number(from: payload["used_percent"]),
+              let windowMinutes = integer(from: payload["window_minutes"]) else { return nil }
+
+        return CodexUsageWindow(
+            key: key,
+            label: windowLabel(forMinutes: windowMinutes),
+            usedPercentage: usedPercentage,
+            leftPercentage: max(0, 100 - usedPercentage),
+            windowMinutes: windowMinutes,
+            resetsAt: date(from: payload["resets_at"])
+        )
+    }
+
+    private static func windowLabel(forMinutes minutes: Int) -> String {
+        let days = minutes / 1_440
+        let remainingMinutesAfterDays = minutes % 1_440
+        let hours = remainingMinutesAfterDays / 60
+        let remainingMinutes = remainingMinutesAfterDays % 60
+
+        if days > 0, hours == 0, remainingMinutes == 0 { return "\(days)d" }
+        if days > 0, hours > 0 { return "\(days)d \(hours)h" }
+        if hours > 0, remainingMinutes == 0 { return "\(hours)h" }
+        if hours > 0 { return "\(hours)h \(remainingMinutes)m" }
+        return "\(minutes)m"
+    }
+
+    private static func jsonObject(for line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any] else { return nil }
+        return dictionary
+    }
+
+    private static func timestamp(from value: Any?) -> Date? {
+        guard let string = value as? String else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string)
+    }
+
+    private static func number(from value: Any?) -> Double? {
+        switch value {
+        case let number as NSNumber: return number.doubleValue
+        case let string as String: return Double(string)
+        default: return nil
+        }
+    }
+
+    private static func integer(from value: Any?) -> Int? {
+        switch value {
+        case let number as NSNumber: return number.intValue
+        case let string as String: return Int(string)
+        default: return nil
+        }
+    }
+
+    private static func date(from value: Any?) -> Date? {
+        switch value {
+        case let number as NSNumber: return Date(timeIntervalSince1970: number.doubleValue)
+        case let string as String:
+            guard let seconds = Double(string) else { return nil }
+            return Date(timeIntervalSince1970: seconds)
+        default: return nil
+        }
+    }
+
+    private static func string(from value: Any?) -> String? {
+        switch value {
+        case let string as String: return string.isEmpty ? nil : string
+        case let number as NSNumber: return number.stringValue
+        default: return nil
+        }
+    }
+}

--- a/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
+++ b/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
@@ -28,11 +28,14 @@ struct TerminalAppRegistry: Sendable {
         "urxvt",
         "xterm",
         "cmux",
+        "Electron",       // VS Code (macOS binary name in ps)
         "Code",           // VS Code
         "Code - Insiders",
         "Cursor",
         "Windsurf",
-        "zed"
+        "codex",          // Codex CLI
+        "zed",
+        "Zellij"
     ]
 
     /// Bundle identifiers for terminal apps (for window enumeration)
@@ -71,6 +74,9 @@ struct TerminalAppRegistry: Sendable {
             ("hyper", "Hyper"),
             ("tabby", "Tabby"),
             ("cmux", "cmux"),
+            ("zellij", "Zellij"),
+            ("codex", "Codex"),      // must be before "code" to avoid VS Code match
+            ("electron", "VS Code"), // VS Code binary name as seen in ps on macOS
             ("code", "VS Code"),
             ("cursor", "Cursor"),
             ("windsurf", "Windsurf"),

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -145,7 +145,13 @@ actor SessionStore {
         var session = sessions[sessionId] ?? createSession(from: event)
 
         session.pid = event.pid
-        if let pid = event.pid {
+        if event.source == "codex" {
+            // Codex sessions: always set "Codex" as terminal app, skip process tree
+            session.terminalApp = "Codex"
+            if let transcriptPath = event.transcriptPath, !transcriptPath.isEmpty {
+                session.codexTranscriptPath = transcriptPath
+            }
+        } else if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
             session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
             // Detect terminal app name
@@ -154,6 +160,10 @@ actor SessionStore {
                let termInfo = tree[termPid] {
                 let command = URL(fileURLWithPath: termInfo.command).lastPathComponent
                 session.terminalApp = TerminalAppRegistry.displayName(for: command)
+            }
+            // Fall back to env-detected terminal hint from hook script
+            if session.terminalApp == nil {
+                session.terminalApp = event.terminalApp
             }
             if isNewSession {
                 DebugLogger.log("Hook", "pid=\(pid) tmux=\(session.isInTmux) termApp=\(session.terminalApp ?? "nil")")
@@ -193,8 +203,10 @@ actor SessionStore {
         }
 
         // Parse conversationInfo only when needed (not on every event — too expensive for large JSONL)
-        if session.conversationInfo.firstUserMessage == nil ||
-           (session.phase == .waitingForInput && session.conversationInfo.lastMessage == nil) {
+        // Skip for Codex sessions — they have no Claude JSONL file
+        if event.source != "codex" &&
+           (session.conversationInfo.firstUserMessage == nil ||
+           (session.phase == .waitingForInput && session.conversationInfo.lastMessage == nil)) {
             DebugLogger.log("Store", "Parsing conversationInfo for \(sessionId.prefix(8))")
             let conversationInfo = await ConversationParser.shared.parse(
                 sessionId: sessionId,
@@ -209,7 +221,12 @@ actor SessionStore {
         sessions[sessionId] = session
         publishState()
 
-        if event.shouldSyncFile {
+        if event.source == "codex" {
+            // Codex: sync chat history from rollout JSONL instead of Claude JSONL
+            if let transcriptPath = session.codexTranscriptPath, event.shouldSyncFile {
+                scheduleCodexHistorySync(sessionId: sessionId, transcriptPath: transcriptPath)
+            }
+        } else if event.shouldSyncFile {
             scheduleFileSync(sessionId: sessionId, cwd: event.cwd)
         }
     }
@@ -962,7 +979,32 @@ actor SessionStore {
     // MARK: - History Loading
 
     private func loadHistoryFromFile(sessionId: String, cwd: String) async {
-        // Parse file asynchronously
+        // Codex sessions: parse rollout JSONL instead of Claude JSONL
+        if let transcriptPath = sessions[sessionId]?.codexTranscriptPath, !transcriptPath.isEmpty {
+            let messages = CodexChatHistoryParser.parse(transcriptPath: transcriptPath)
+            let firstUserMsg = messages.first(where: { $0.role == .user })
+            let lastUserMsg = messages.last(where: { $0.role == .user })
+            let conversationInfo = ConversationInfo(
+                summary: nil,
+                lastMessage: messages.last?.textContent,
+                lastMessageRole: messages.last?.role.rawValue,
+                lastToolName: nil,
+                firstUserMessage: firstUserMsg?.textContent,
+                latestUserMessage: lastUserMsg?.textContent,
+                lastUserMessageDate: lastUserMsg?.timestamp
+            )
+            await process(.historyLoaded(
+                sessionId: sessionId,
+                messages: messages,
+                completedTools: [],
+                toolResults: [:],
+                structuredResults: [:],
+                conversationInfo: conversationInfo
+            ))
+            return
+        }
+
+        // Claude sessions: parse from JSONL
         let messages = await ConversationParser.shared.parseFullConversation(
             sessionId: sessionId,
             cwd: cwd
@@ -1071,6 +1113,38 @@ actor SessionStore {
             )
 
             await self?.process(.fileUpdated(payload))
+        }
+    }
+
+    private func scheduleCodexHistorySync(sessionId: String, transcriptPath: String) {
+        cancelPendingSync(sessionId: sessionId)
+
+        pendingSyncs[sessionId] = Task { [weak self, syncDebounceNs] in
+            try? await Task.sleep(nanoseconds: syncDebounceNs)
+            guard !Task.isCancelled else { return }
+
+            let messages = CodexChatHistoryParser.parse(transcriptPath: transcriptPath)
+            guard !messages.isEmpty else { return }
+
+            let firstUserMsg = messages.first(where: { $0.role == .user })
+            let lastUserMsg = messages.last(where: { $0.role == .user })
+            let conversationInfo = ConversationInfo(
+                summary: nil,
+                lastMessage: messages.last?.textContent,
+                lastMessageRole: messages.last?.role.rawValue,
+                lastToolName: nil,
+                firstUserMessage: firstUserMsg?.textContent,
+                latestUserMessage: lastUserMsg?.textContent,
+                lastUserMessageDate: lastUserMsg?.timestamp
+            )
+            await self?.process(.historyLoaded(
+                sessionId: sessionId,
+                messages: messages,
+                completedTools: [],
+                toolResults: [:],
+                structuredResults: [:],
+                conversationInfo: conversationInfo
+            ))
         }
     }
 

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -521,17 +521,20 @@ struct InstanceRow: View {
         let tag = terminalTag.lowercased()
         if tag.contains("cmux") { return Color(red: 0.56, green: 0.79, blue: 0.98) }      // blue
         if tag.contains("ghostty") { return Color(red: 0.7, green: 0.6, blue: 1.0) }       // purple
+        if tag.contains("zellij") { return Color(red: 0.3, green: 0.85, blue: 0.75) }     // teal
         if tag.contains("iterm") { return Color(red: 0.29, green: 0.87, blue: 0.5) }       // green
         if tag.contains("warp") { return Color(red: 0.96, green: 0.62, blue: 0.04) }       // amber
         if tag.contains("cursor") { return Color(red: 0.4, green: 0.91, blue: 0.98) }      // cyan
+        if tag.contains("codex") { return Color(red: 1.0, green: 0.55, blue: 0.0) }        // orange
         if tag.contains("code") { return Color(red: 0.29, green: 0.67, blue: 0.96) }       // vs blue
         if tag.contains("kitty") { return Color(red: 0.94, green: 0.5, blue: 0.5) }        // salmon
+        if tag.contains("claude") { return Self.claudeTagFg }                               // claude blue
         return Color.white.opacity(0.4)
     }
 
-    /// Terminal app name — auto-detected from process tree
+    /// Terminal app name — auto-detected from process tree; falls back to "claude" for plain CLI sessions
     private var terminalTag: String {
-        session.terminalApp ?? (session.isInTmux ? "tmux" : "term")
+        session.terminalApp ?? (session.isInTmux ? "tmux" : "claude")
     }
 
     /// Accent color based on phase (used for status dot)


### PR DESCRIPTION
…hat history

Adds full Codex CLI support as a second agent source alongside Claude Code:
- Hook scripts (codeisland-state.py, new codex-specific hooks) forward events via /tmp/codeisland.sock; Codex detected via presence of "model" field
- CodexSessionTracking, CodexHooks, CodexUsage: session lifecycle, prompt/stop events, token usage tracking
- CodexChatHistoryParser: parses rollout JSONL from ~/.codex/archived_sessions/
- CodexHookInstaller/Manager: install and manage the Codex hook
- Terminal badge: Codex sessions show "Codex"; Claude sessions detect terminal via process tree then env-var fallback (ZELLIJ, GHOSTTY_RESOURCES_DIR, etc.); TerminalAppRegistry gains Electron→VS Code and codex→Codex mappings
- SessionStore wires source discrimination: source=="codex" → Codex history sync

- The Codex hook integration is based on https://github.com/Octane0411/open-vibe-island