### PR TITLE
feat: per-screen notch height customization / 按显示器独立配置刘海高度

### DIFF
--- a/ClaudeIsland/Core/Ext+NSScreen.swift
+++ b/ClaudeIsland/Core/Ext+NSScreen.swift
@@ -50,4 +50,11 @@ extension NSScreen {
     var hasPhysicalNotch: Bool {
         safeAreaInsets.top > 0
     }
+
+    /// Stable string identifier for per-screen settings persistence.
+    /// Derived from CGDirectDisplayID.
+    var persistentID: String {
+        let id = (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) ?? 0
+        return String(id)
+    }
 }

--- a/ClaudeIsland/Core/Ext+NSScreen.swift
+++ b/ClaudeIsland/Core/Ext+NSScreen.swift
@@ -52,9 +52,22 @@ extension NSScreen {
     }
 
     /// Stable string identifier for per-screen settings persistence.
-    /// Derived from CGDirectDisplayID.
+    /// Uses vendor+model+serial for external displays (survives reboots
+    /// and port changes). Falls back to CGDirectDisplayID when the
+    /// hardware identifiers are unavailable (returns 0 for all three).
     var persistentID: String {
-        let id = (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) ?? 0
-        return String(id)
+        guard let displayID = deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+            return "0"
+        }
+        let vendor = CGDisplayVendorNumber(displayID)
+        let model  = CGDisplayModelNumber(displayID)
+        let serial = CGDisplaySerialNumber(displayID)
+        // If hardware identifiers are available, use the stable composite key.
+        // The triple (0,0,0) means the display doesn't report EDID data —
+        // fall back to the session-scoped CGDirectDisplayID.
+        if vendor == 0, model == 0, serial == 0 {
+            return String(displayID)
+        }
+        return "\(vendor)-\(model)-\(serial)"
     }
 }

--- a/ClaudeIsland/Core/NotchHardwareDetector.swift
+++ b/ClaudeIsland/Core/NotchHardwareDetector.swift
@@ -45,6 +45,19 @@ enum NotchHardwareDetector {
     /// tiny indicator" at default font scale.
     static let minIdleWidth: CGFloat = 140
 
+    // MARK: - Notch height clamp
+
+    /// Minimum custom notch height — ensures the notch is always visible.
+    static let minNotchHeight: CGFloat = 20
+
+    /// Maximum custom notch height — prevents excessive screen coverage.
+    static let maxNotchHeight: CGFloat = 80
+
+    /// Clamp a user-provided notch height to the valid range. Pure function.
+    static func clampedHeight(_ height: CGFloat) -> CGFloat {
+        max(minNotchHeight, min(height, maxNotchHeight))
+    }
+
     /// Clamp the measured content width against the user's
     /// `maxWidth` and the hard `minIdleWidth` floor. Pure function;
     /// no global state.

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -63,6 +63,7 @@ class NotchViewModel: ObservableObject {
     let geometry: NotchGeometry
     let spacing: CGFloat = 12
     let hasPhysicalNotch: Bool
+    let screenID: String
 
     /// Current expansion width from NotchView (synced for hit testing)
     @Published var currentExpansionWidth: CGFloat = 240
@@ -159,7 +160,8 @@ class NotchViewModel: ObservableObject {
 
     // MARK: - Initialization
 
-    init(deviceNotchRect: CGRect, screenRect: CGRect, windowHeight: CGFloat, hasPhysicalNotch: Bool) {
+    init(deviceNotchRect: CGRect, screenRect: CGRect, windowHeight: CGFloat, hasPhysicalNotch: Bool, screenID: String) {
+        self.screenID = screenID
         self.geometry = NotchGeometry(
             deviceNotchRect: deviceNotchRect,
             screenRect: screenRect,
@@ -213,10 +215,10 @@ class NotchViewModel: ObservableObject {
     /// when the smaller built-in is the active one. Mirrors the same
     /// clamp NotchView applies for `.offset(x:)` rendering.
     private var currentHorizontalOffset: CGFloat {
-        let stored = NotchCustomizationStore.shared.customization.horizontalOffset
+        let geo = NotchCustomizationStore.shared.customization.geometry(for: screenID)
         let runtime: CGFloat = status == .opened ? openedSize.width : (geometry.deviceNotchRect.width + currentExpansionWidth)
         return NotchHardwareDetector.clampedHorizontalOffset(
-            storedOffset: stored,
+            storedOffset: geo.horizontalOffset,
             runtimeWidth: runtime,
             screenWidth: geometry.screenRect.width
         )

--- a/ClaudeIsland/Models/NotchCustomization.swift
+++ b/ClaudeIsland/Models/NotchCustomization.swift
@@ -12,6 +12,16 @@
 import CoreGraphics
 import Foundation
 
+/// Per-screen geometry settings. Keyed by screen's CGDirectDisplayID
+/// in NotchCustomization.screenGeometries.
+struct ScreenGeometry: Codable, Equatable {
+    var maxWidth: CGFloat = 440
+    var horizontalOffset: CGFloat = 0
+    var notchHeight: CGFloat = 38
+
+    static let `default` = ScreenGeometry()
+}
+
 struct NotchCustomization: Codable, Equatable {
     // Appearance
     var theme: NotchThemeID
@@ -21,13 +31,9 @@ struct NotchCustomization: Codable, Equatable {
     var showBuddy: Bool
     var showUsageBar: Bool
 
-    // Geometry — all user-controlled via live edit mode.
-    /// Upper bound for auto-expand. Idle content shrinks below this;
-    /// long content expands up to this and truncates beyond.
-    var maxWidth: CGFloat
-    /// Signed horizontal offset from the screen's center (pinned to top).
-    /// Render-time clamped; stored value preserved for later screen changes.
-    var horizontalOffset: CGFloat
+    // Per-screen geometry
+    var screenGeometries: [String: ScreenGeometry] = [:]
+    var defaultGeometry: ScreenGeometry = .init()
 
     // Hardware notch override
     var hardwareNotchMode: HardwareNotchMode
@@ -37,20 +43,28 @@ struct NotchCustomization: Codable, Equatable {
         fontScale: FontScale = .default,
         showBuddy: Bool = true,
         showUsageBar: Bool = true,
-        maxWidth: CGFloat = 440,
-        horizontalOffset: CGFloat = 0,
         hardwareNotchMode: HardwareNotchMode = .auto
     ) {
         self.theme = theme
         self.fontScale = fontScale
         self.showBuddy = showBuddy
         self.showUsageBar = showUsageBar
-        self.maxWidth = maxWidth
-        self.horizontalOffset = horizontalOffset
         self.hardwareNotchMode = hardwareNotchMode
     }
 
     static let `default` = NotchCustomization()
+
+    // MARK: - Per-screen geometry helpers
+
+    func geometry(for screenID: String) -> ScreenGeometry {
+        screenGeometries[screenID] ?? defaultGeometry
+    }
+
+    mutating func updateGeometry(for screenID: String, _ body: (inout ScreenGeometry) -> Void) {
+        var geo = geometry(for: screenID)
+        body(&geo)
+        screenGeometries[screenID] = geo
+    }
 
     // MARK: - Forward-compat Codable
     //
@@ -62,7 +76,8 @@ struct NotchCustomization: Codable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case theme, fontScale, showBuddy, showUsageBar,
-             maxWidth, horizontalOffset, hardwareNotchMode
+             hardwareNotchMode, screenGeometries, defaultGeometry,
+             maxWidth, horizontalOffset // legacy keys for migration
     }
 
     init(from decoder: Decoder) throws {
@@ -71,9 +86,28 @@ struct NotchCustomization: Codable, Equatable {
         self.fontScale = try c.decodeIfPresent(FontScale.self, forKey: .fontScale) ?? .default
         self.showBuddy = try c.decodeIfPresent(Bool.self, forKey: .showBuddy) ?? true
         self.showUsageBar = try c.decodeIfPresent(Bool.self, forKey: .showUsageBar) ?? true
-        self.maxWidth = try c.decodeIfPresent(CGFloat.self, forKey: .maxWidth) ?? 440
-        self.horizontalOffset = try c.decodeIfPresent(CGFloat.self, forKey: .horizontalOffset) ?? 0
         self.hardwareNotchMode = try c.decodeIfPresent(HardwareNotchMode.self, forKey: .hardwareNotchMode) ?? .auto
+        self.screenGeometries = try c.decodeIfPresent([String: ScreenGeometry].self, forKey: .screenGeometries) ?? [:]
+        self.defaultGeometry = try c.decodeIfPresent(ScreenGeometry.self, forKey: .defaultGeometry) ?? .init()
+
+        // Legacy migration: old top-level geometry fields -> defaultGeometry
+        if let legacyWidth = try c.decodeIfPresent(CGFloat.self, forKey: .maxWidth) {
+            self.defaultGeometry.maxWidth = legacyWidth
+        }
+        if let legacyOffset = try c.decodeIfPresent(CGFloat.self, forKey: .horizontalOffset) {
+            self.defaultGeometry.horizontalOffset = legacyOffset
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(theme, forKey: .theme)
+        try c.encode(fontScale, forKey: .fontScale)
+        try c.encode(showBuddy, forKey: .showBuddy)
+        try c.encode(showUsageBar, forKey: .showUsageBar)
+        try c.encode(hardwareNotchMode, forKey: .hardwareNotchMode)
+        try c.encode(screenGeometries, forKey: .screenGeometries)
+        try c.encode(defaultGeometry, forKey: .defaultGeometry)
     }
 }
 

--- a/ClaudeIsland/Models/NotchCustomization.swift
+++ b/ClaudeIsland/Models/NotchCustomization.swift
@@ -88,14 +88,21 @@ struct NotchCustomization: Codable, Equatable {
         self.showUsageBar = try c.decodeIfPresent(Bool.self, forKey: .showUsageBar) ?? true
         self.hardwareNotchMode = try c.decodeIfPresent(HardwareNotchMode.self, forKey: .hardwareNotchMode) ?? .auto
         self.screenGeometries = try c.decodeIfPresent([String: ScreenGeometry].self, forKey: .screenGeometries) ?? [:]
-        self.defaultGeometry = try c.decodeIfPresent(ScreenGeometry.self, forKey: .defaultGeometry) ?? .init()
 
-        // Legacy migration: old top-level geometry fields -> defaultGeometry
-        if let legacyWidth = try c.decodeIfPresent(CGFloat.self, forKey: .maxWidth) {
-            self.defaultGeometry.maxWidth = legacyWidth
-        }
-        if let legacyOffset = try c.decodeIfPresent(CGFloat.self, forKey: .horizontalOffset) {
-            self.defaultGeometry.horizontalOffset = legacyOffset
+        if let existing = try c.decodeIfPresent(ScreenGeometry.self, forKey: .defaultGeometry) {
+            // New-format blob: use as-is, ignore any stale legacy keys
+            self.defaultGeometry = existing
+        } else {
+            // No defaultGeometry key — either legacy blob or fresh install.
+            // Migrate old top-level fields into a fresh default.
+            var geo = ScreenGeometry()
+            if let legacyWidth = try c.decodeIfPresent(CGFloat.self, forKey: .maxWidth) {
+                geo.maxWidth = legacyWidth
+            }
+            if let legacyOffset = try c.decodeIfPresent(CGFloat.self, forKey: .horizontalOffset) {
+                geo.horizontalOffset = legacyOffset
+            }
+            self.defaultGeometry = geo
         }
     }
 

--- a/ClaudeIsland/Services/State/NotchCustomizationStore.swift
+++ b/ClaudeIsland/Services/State/NotchCustomizationStore.swift
@@ -61,6 +61,11 @@ final class NotchCustomizationStore: ObservableObject {
         save()
     }
 
+    /// Convenience for updating geometry of a specific screen.
+    func updateGeometry(for screenID: String, _ mutation: (inout ScreenGeometry) -> Void) {
+        update { $0.updateGeometry(for: screenID, mutation) }
+    }
+
     // MARK: - Live edit lifecycle
 
     func enterEditMode() {

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -29,6 +29,7 @@ enum NotchEditSubMode {
 }
 
 struct NotchLiveEditOverlay: View {
+    let screenID: String
     @ObservedObject private var store: NotchCustomizationStore = .shared
     @State private var subMode: NotchEditSubMode = .resize
     @State private var presetMarkerVisible: Bool = false
@@ -61,7 +62,13 @@ struct NotchLiveEditOverlay: View {
     /// edit-mode visuals (dashed border + drag-catcher) we anchor
     /// to the closed-state height so the interactive region matches
     /// the resting visual.
-    private let visibleNotchHeight: CGFloat = 38
+    private var visibleNotchHeight: CGFloat {
+        if hasHardwareNotch {
+            return 38
+        }
+        let geo = store.customization.geometry(for: screenID)
+        return NotchHardwareDetector.clampedHeight(geo.notchHeight)
+    }
 
     /// Hardware notch width on the active screen, honoring the
     /// `hardwareNotchMode` override. Falls back to 200pt for the
@@ -77,7 +84,8 @@ struct NotchLiveEditOverlay: View {
 
     /// User-controlled wing expansion derived from `maxWidth`.
     private var userExpansion: CGFloat {
-        max(0, store.customization.maxWidth - baseNotchWidth)
+        let geo = store.customization.geometry(for: screenID)
+        return max(0, geo.maxWidth - baseNotchWidth)
     }
 
     /// Total visible notch width (hardware width + wings).
@@ -98,10 +106,12 @@ struct NotchLiveEditOverlay: View {
     /// user can tell when they've dragged off-center. Both rounded
     /// to whole points for legibility.
     private var readoutText: String {
-        let width = Int(store.customization.maxWidth.rounded())
-        let offset = Int(store.customization.horizontalOffset.rounded())
+        let geo = store.customization.geometry(for: screenID)
+        let width = Int(geo.maxWidth.rounded())
+        let height = Int(visibleNotchHeight.rounded())
+        let offset = Int(geo.horizontalOffset.rounded())
         let offsetSign = offset > 0 ? "+\(offset)" : "\(offset)"
-        return "W \(width)pt   X \(offsetSign)pt"
+        return "W \(width)pt   H \(height)pt   X \(offsetSign)pt"
     }
 
     var body: some View {
@@ -110,7 +120,7 @@ struct NotchLiveEditOverlay: View {
 
             // Mirror the same clamp NotchView applies for `.offset(x:)`.
             let clampedOffset = NotchHardwareDetector.clampedHorizontalOffset(
-                storedOffset: store.customization.horizontalOffset,
+                storedOffset: store.customization.geometry(for: screenID).horizontalOffset,
                 runtimeWidth: visibleNotchWidth,
                 screenWidth: panelWidth
             )
@@ -174,11 +184,11 @@ struct NotchLiveEditOverlay: View {
                             DragGesture(minimumDistance: 0)
                                 .onChanged { value in
                                     if dragStartOffset == nil {
-                                        dragStartOffset = store.customization.horizontalOffset
+                                        dragStartOffset = store.customization.geometry(for: screenID).horizontalOffset
                                     }
                                     let start = dragStartOffset ?? 0
-                                    store.update {
-                                        $0.horizontalOffset = start + value.translation.width
+                                    store.updateGeometry(for: screenID) { geo in
+                                        geo.horizontalOffset = start + value.translation.width
                                     }
                                 }
                                 .onEnded { _ in
@@ -194,6 +204,13 @@ struct NotchLiveEditOverlay: View {
 
                 arrowButton(direction: +1, label: "Grow notch")
                     .position(x: notchRightX + 28, y: notchVerticalCenter)
+
+                // 4b. Height arrow buttons (▲ ▼) above/below the notch.
+                heightArrowButton(direction: +1, label: "Increase notch height")
+                    .position(x: notchCenterX, y: -10)
+
+                heightArrowButton(direction: -1, label: "Decrease notch height")
+                    .position(x: notchCenterX, y: visibleNotchHeight + 14)
 
                 // 5. Live width + offset readout — small monospaced
                 //    label below the notch so the user can see exact
@@ -244,9 +261,10 @@ struct NotchLiveEditOverlay: View {
                             enabled: true
                         ) {
                             withAnimation(.easeInOut(duration: 0.25)) {
-                                store.update {
-                                    $0.maxWidth = NotchCustomization.default.maxWidth
-                                    $0.horizontalOffset = NotchCustomization.default.horizontalOffset
+                                store.updateGeometry(for: screenID) { geo in
+                                    geo.maxWidth = ScreenGeometry.default.maxWidth
+                                    geo.horizontalOffset = ScreenGeometry.default.horizontalOffset
+                                    geo.notchHeight = ScreenGeometry.default.notchHeight
                                 }
                                 subMode = .resize
                                 dragStartOffset = nil
@@ -319,6 +337,40 @@ struct NotchLiveEditOverlay: View {
         .accessibilityHint("Hold Command for a larger step, hold Option for a finer step.")
     }
 
+    private func heightArrowButton(direction: Int, label: String) -> some View {
+        Button {
+            applyHeightStep(direction: direction)
+        } label: {
+            Image(systemName: direction > 0 ? "chevron.up" : "chevron.down")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(hasHardwareNotch ? .white.opacity(0.35) : .black)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(hasHardwareNotch ? Color.black.opacity(0.5) : neonGreen))
+                .shadow(color: hasHardwareNotch ? .clear : neonGreen.opacity(0.45), radius: 6)
+        }
+        .buttonStyle(.plain)
+        .disabled(hasHardwareNotch)
+        .accessibilityLabel(label)
+        .accessibilityHint(hasHardwareNotch ? "Disabled: hardware notch height is fixed" : "Hold Command for a larger step, hold Option for a finer step.")
+    }
+
+    private func applyHeightStep(direction: Int) {
+        let flags = NSEvent.modifierFlags
+        let step: CGFloat
+        if flags.contains(.command) {
+            step = 10
+        } else if flags.contains(.option) {
+            step = 1
+        } else {
+            step = 4
+        }
+        store.updateGeometry(for: screenID) { geo in
+            geo.notchHeight = NotchHardwareDetector.clampedHeight(
+                geo.notchHeight + CGFloat(direction) * step
+            )
+        }
+    }
+
     private func applyArrowStep(direction: Int) {
         let flags = NSEvent.modifierFlags
         let step: CGFloat
@@ -329,10 +381,10 @@ struct NotchLiveEditOverlay: View {
         } else {
             step = 4
         }
-        store.update { c in
-            c.maxWidth = max(
+        store.updateGeometry(for: screenID) { geo in
+            geo.maxWidth = max(
                 NotchHardwareDetector.minIdleWidth,
-                c.maxWidth + CGFloat(direction) * step
+                geo.maxWidth + CGFloat(direction) * step
             )
         }
     }
@@ -343,9 +395,9 @@ struct NotchLiveEditOverlay: View {
             mode: store.customization.hardwareNotchMode
         )
         guard width > 0 else { return }
-        store.update { c in
-            c.maxWidth = width + 20
-            c.horizontalOffset = 0
+        store.updateGeometry(for: screenID) { geo in
+            geo.maxWidth = width + 20
+            geo.horizontalOffset = 0
         }
         // Flash the dashed marker for ~2s.
         withAnimation(.easeIn(duration: 0.2)) {

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -341,7 +341,7 @@ struct NotchLiveEditOverlay: View {
         Button {
             applyHeightStep(direction: direction)
         } label: {
-            Image(systemName: direction > 0 ? "chevron.up" : "chevron.down")
+            Image(systemName: direction > 0 ? "chevron.down" : "chevron.up")
                 .font(.system(size: 14, weight: .bold))
                 .foregroundColor(hasHardwareNotch ? .white.opacity(0.35) : .black)
                 .frame(width: 32, height: 32)

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -205,17 +205,16 @@ struct NotchLiveEditOverlay: View {
                 arrowButton(direction: +1, label: "Grow notch")
                     .position(x: notchRightX + 28, y: notchVerticalCenter)
 
-                // 4b. Height arrow buttons (▲ ▼) below the notch.
-                // Both sit under the notch bottom edge; ▲ increases, ▼ decreases.
-                heightArrowButton(direction: +1, label: "Increase notch height")
+                // 4b. Height arrow buttons (▼ ▲) below the notch.
+                // Left: decrease height, Right: increase height.
+                heightArrowButton(direction: -1, label: "Decrease notch height")
                     .position(x: notchCenterX - 22, y: visibleNotchHeight + 14)
 
-                heightArrowButton(direction: -1, label: "Decrease notch height")
+                heightArrowButton(direction: +1, label: "Increase notch height")
                     .position(x: notchCenterX + 22, y: visibleNotchHeight + 14)
 
                 // 5. Live width + offset readout — small monospaced
-                //    label below the notch so the user can see exact
-                //    numbers as they drag the arrows / move the notch.
+                //    label below the height arrows so it doesn't overlap.
                 Text(readoutText)
                     .font(.system(size: 10, weight: .semibold, design: .monospaced))
                     .foregroundColor(.white.opacity(0.7))
@@ -224,7 +223,7 @@ struct NotchLiveEditOverlay: View {
                     .background(
                         Capsule().fill(Color.black.opacity(0.6))
                     )
-                    .position(x: notchCenterX, y: visibleNotchHeight + 24)
+                    .position(x: notchCenterX, y: visibleNotchHeight + 44)
                     .accessibilityHidden(true)
 
                 // 6. Action row + Reset + Save/Cancel — stacked
@@ -314,7 +313,7 @@ struct NotchLiveEditOverlay: View {
                         .accessibilityLabel("Cancel notch customization")
                     }
                 }
-                .position(x: notchCenterX, y: visibleNotchHeight + 70)
+                .position(x: notchCenterX, y: visibleNotchHeight + 90)
             }
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
         }

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -205,12 +205,12 @@ struct NotchLiveEditOverlay: View {
                 arrowButton(direction: +1, label: "Grow notch")
                     .position(x: notchRightX + 28, y: notchVerticalCenter)
 
-                // 4b. Height arrow buttons (▲ ▼) below the notch.
-                // Left: increase height, Right: decrease height.
-                heightArrowButton(direction: +1, label: "Increase notch height")
+                // 4b. Height arrow buttons (▼ ▲) below the notch.
+                // Left: decrease height, Right: increase height.
+                heightArrowButton(direction: -1, label: "Decrease notch height")
                     .position(x: notchCenterX - 22, y: visibleNotchHeight + 14)
 
-                heightArrowButton(direction: -1, label: "Decrease notch height")
+                heightArrowButton(direction: +1, label: "Increase notch height")
                     .position(x: notchCenterX + 22, y: visibleNotchHeight + 14)
 
                 // 5. Live width + offset readout — small monospaced

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -205,12 +205,12 @@ struct NotchLiveEditOverlay: View {
                 arrowButton(direction: +1, label: "Grow notch")
                     .position(x: notchRightX + 28, y: notchVerticalCenter)
 
-                // 4b. Height arrow buttons (▼ ▲) below the notch.
-                // Left: decrease height, Right: increase height.
-                heightArrowButton(direction: -1, label: "Decrease notch height")
+                // 4b. Height arrow buttons (▲ ▼) below the notch.
+                // Left: increase height, Right: decrease height.
+                heightArrowButton(direction: +1, label: "Increase notch height")
                     .position(x: notchCenterX - 22, y: visibleNotchHeight + 14)
 
-                heightArrowButton(direction: +1, label: "Increase notch height")
+                heightArrowButton(direction: -1, label: "Decrease notch height")
                     .position(x: notchCenterX + 22, y: visibleNotchHeight + 14)
 
                 // 5. Live width + offset readout — small monospaced

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -205,12 +205,13 @@ struct NotchLiveEditOverlay: View {
                 arrowButton(direction: +1, label: "Grow notch")
                     .position(x: notchRightX + 28, y: notchVerticalCenter)
 
-                // 4b. Height arrow buttons (▲ ▼) above/below the notch.
+                // 4b. Height arrow buttons (▲ ▼) below the notch.
+                // Both sit under the notch bottom edge; ▲ increases, ▼ decreases.
                 heightArrowButton(direction: +1, label: "Increase notch height")
-                    .position(x: notchCenterX, y: -10)
+                    .position(x: notchCenterX - 22, y: visibleNotchHeight + 14)
 
                 heightArrowButton(direction: -1, label: "Decrease notch height")
-                    .position(x: notchCenterX, y: visibleNotchHeight + 14)
+                    .position(x: notchCenterX + 22, y: visibleNotchHeight + 14)
 
                 // 5. Live width + offset readout — small monospaced
                 //    label below the notch so the user can see exact

--- a/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+++ b/ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
@@ -12,7 +12,7 @@
 //    the active screen. So panel x=0 corresponds to the screen's
 //    left edge and the screen's mid X is panel.size.width/2.
 //  - The visible notch is rendered by NotchView at screen-mid plus
-//    `customization.horizontalOffset`. We mirror that math here so
+//    the per-screen `ScreenGeometry.horizontalOffset`. We mirror that math here so
 //    the dashed border, drag-catcher, and arrow buttons all align
 //    pixel-for-pixel with the real notch.
 //

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -155,7 +155,7 @@ struct NotchView: View {
 
     /// Extra width for expanding activities (like Dynamic Island).
     ///
-    /// Reads from `notchStore.customization.maxWidth` so the live edit
+    /// Reads from the per-screen `ScreenGeometry.maxWidth` so the live edit
     /// "resize" arrow buttons visibly grow / shrink the notch as the
     /// user drives the slider. The user's `maxWidth` is the total
     /// closed-with-content width — subtracting the hardware notch

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -140,9 +140,16 @@ struct NotchView: View {
     // MARK: - Sizing
 
     private var closedNotchSize: CGSize {
-        CGSize(
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        let height: CGFloat
+        if viewModel.hasPhysicalNotch {
+            height = viewModel.deviceNotchRect.height
+        } else {
+            height = NotchHardwareDetector.clampedHeight(geo.notchHeight)
+        }
+        return CGSize(
             width: viewModel.deviceNotchRect.width,
-            height: viewModel.deviceNotchRect.height
+            height: height
         )
     }
 
@@ -161,7 +168,8 @@ struct NotchView: View {
     /// the hardware shape.
     private var expansionWidth: CGFloat {
         guard hasActiveSessions else { return 0 }
-        let userMax = notchStore.customization.maxWidth
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        let userMax = geo.maxWidth
         let userExpansion = max(0, userMax - closedNotchSize.width)
         if compactCollapsed {
             return min(100, userExpansion)
@@ -212,8 +220,9 @@ struct NotchView: View {
     /// render time so an off-screen stored value on a smaller
     /// secondary display never bleeds past the edge. Spec 5.5.
     private var clampedHorizontalOffset: CGFloat {
-        NotchHardwareDetector.clampedHorizontalOffset(
-            storedOffset: notchStore.customization.horizontalOffset,
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        return NotchHardwareDetector.clampedHorizontalOffset(
+            storedOffset: geo.horizontalOffset,
             runtimeWidth: viewModel.status == .opened ? notchSize.width : closedContentWidth,
             screenWidth: viewModel.screenRect.width
         )

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class NotchWindowController: NSWindowController {
     let viewModel: NotchViewModel
     private let screen: NSScreen
+    let screenID: String
     private var cancellables = Set<AnyCancellable>()
 
     /// Subscription to NotchCustomizationStore.$customization. Held
@@ -27,6 +28,7 @@ class NotchWindowController: NSWindowController {
 
     init(screen: NSScreen) {
         self.screen = screen
+        self.screenID = screen.persistentID
 
         let screenFrame = screen.frame
         let notchSize = screen.notchSize
@@ -53,7 +55,8 @@ class NotchWindowController: NSWindowController {
             deviceNotchRect: deviceNotchRect,
             screenRect: screenFrame,
             windowHeight: windowHeight,
-            hasPhysicalNotch: screen.hasPhysicalNotch
+            hasPhysicalNotch: screen.hasPhysicalNotch,
+            screenID: screen.persistentID
         )
 
         // Create the window
@@ -158,6 +161,7 @@ class NotchWindowController: NSWindowController {
         // (which can return a non-notched secondary display once the
         // live edit panel becomes key on a multi-monitor setup).
         let overlay = NotchLiveEditOverlay(
+            screenID: screenID,
             screenProvider: { activeScreen },
             onExit: { [weak self] in
                 self?.exitLiveEditMode()
@@ -189,7 +193,7 @@ class NotchWindowController: NSWindowController {
     @MainActor
     func applyGeometryFromStore() {
         let store = NotchCustomizationStore.shared
-        let customization = store.customization
+        let geo = store.customization.geometry(for: screenID)
         let window = self.window
 
         guard let window else { return }
@@ -197,37 +201,22 @@ class NotchWindowController: NSWindowController {
         let screenFrame = activeScreen.frame
 
         let runtimeWidth = NotchHardwareDetector.clampedWidth(
-            measuredContentWidth: customization.maxWidth,
-            maxWidth: customization.maxWidth
+            measuredContentWidth: geo.maxWidth,
+            maxWidth: geo.maxWidth
         )
         let clampedOffset = NotchHardwareDetector.clampedHorizontalOffset(
-            storedOffset: customization.horizontalOffset,
+            storedOffset: geo.horizontalOffset,
             runtimeWidth: runtimeWidth,
             screenWidth: screenFrame.width
         )
         let baseX = (screenFrame.width - runtimeWidth) / 2
         let finalX = screenFrame.origin.x + baseX + clampedOffset
 
-        // The notch panel currently sizes itself to the full
-        // screen width and positions content via inner layout, so
-        // a geometry change here re-flows the internal notch
-        // layout rather than resizing the window. This matches the
-        // existing CodeIsland rendering model and avoids a deeper
-        // refactor of the hosting view geometry. Stored horizontal
-        // offset and width are still observed via the subscription
-        // so NotchView can react directly to store changes.
-        _ = (finalX, runtimeWidth) // Referenced for clarity; full
-                                   // geometry wiring is deferred to
-                                   // the next chunk (live edit mode)
-                                   // where the interactive drag
-                                   // path needs the same math.
+        _ = (finalX, runtimeWidth)
 
-        // Smoothly animate any future frame changes.
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.35
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            // Preserve the current full-width overlay frame; only
-            // the inner notch bounds care about runtimeWidth.
             window.animator().setFrame(window.frame, display: true)
         }
     }

--- a/ClaudeIslandTests/AutoWidthTests.swift
+++ b/ClaudeIslandTests/AutoWidthTests.swift
@@ -91,6 +91,20 @@ final class AutoWidthTests: XCTestCase {
         XCTAssertEqual(clamped, 500)
     }
 
+    // MARK: - clampedHeight
+
+    func test_clampedHeight_withinRange_passesThrough() {
+        XCTAssertEqual(NotchHardwareDetector.clampedHeight(50), 50)
+    }
+
+    func test_clampedHeight_belowMin_returnsMin() {
+        XCTAssertEqual(NotchHardwareDetector.clampedHeight(5), NotchHardwareDetector.minNotchHeight)
+    }
+
+    func test_clampedHeight_aboveMax_returnsMax() {
+        XCTAssertEqual(NotchHardwareDetector.clampedHeight(200), NotchHardwareDetector.maxNotchHeight)
+    }
+
     // MARK: - hasHardwareNotch mode override
 
     func test_hasHardwareNotch_forceVirtual_alwaysFalse() {

--- a/ClaudeIslandTests/NotchCustomizationStoreTests.swift
+++ b/ClaudeIslandTests/NotchCustomizationStoreTests.swift
@@ -87,6 +87,17 @@ final class NotchCustomizationStoreTests: XCTestCase {
         XCTAssertEqual(decoded.theme, .paper)
     }
 
+    func test_updateGeometry_mutatesAndPersists() throws {
+        let store = NotchCustomizationStore()
+        store.updateGeometry(for: "42") { $0.notchHeight = 55 }
+
+        XCTAssertEqual(store.customization.geometry(for: "42").notchHeight, 55)
+
+        let data = try XCTUnwrap(UserDefaults.standard.data(forKey: v1Key))
+        let decoded = try JSONDecoder().decode(NotchCustomization.self, from: data)
+        XCTAssertEqual(decoded.geometry(for: "42").notchHeight, 55)
+    }
+
     // MARK: - Edit lifecycle
 
     func test_enterEditMode_setsIsEditing() {

--- a/ClaudeIslandTests/NotchCustomizationStoreTests.swift
+++ b/ClaudeIslandTests/NotchCustomizationStoreTests.swift
@@ -41,13 +41,13 @@ final class NotchCustomizationStoreTests: XCTestCase {
     func test_init_withExistingV1Key_loadsIt() throws {
         var persisted = NotchCustomization.default
         persisted.theme = .cyber
-        persisted.maxWidth = 520
+        persisted.defaultGeometry.maxWidth = 520
         let data = try JSONEncoder().encode(persisted)
         UserDefaults.standard.set(data, forKey: v1Key)
 
         let store = NotchCustomizationStore()
         XCTAssertEqual(store.customization.theme, .cyber)
-        XCTAssertEqual(store.customization.maxWidth, 520)
+        XCTAssertEqual(store.customization.defaultGeometry.maxWidth, 520)
     }
 
     // MARK: - Migration
@@ -98,22 +98,22 @@ final class NotchCustomizationStoreTests: XCTestCase {
 
     func test_cancelEdit_rollsBackToSnapshot() {
         let store = NotchCustomizationStore()
-        store.update { $0.maxWidth = 400 }
+        store.update { $0.defaultGeometry.maxWidth = 400 }
         store.enterEditMode()
-        store.update { $0.maxWidth = 600 }
-        XCTAssertEqual(store.customization.maxWidth, 600)
+        store.update { $0.defaultGeometry.maxWidth = 600 }
+        XCTAssertEqual(store.customization.defaultGeometry.maxWidth, 600)
         store.cancelEdit()
-        XCTAssertEqual(store.customization.maxWidth, 400)
+        XCTAssertEqual(store.customization.defaultGeometry.maxWidth, 400)
         XCTAssertFalse(store.isEditing)
     }
 
     func test_commitEdit_keepsChanges() {
         let store = NotchCustomizationStore()
-        store.update { $0.maxWidth = 400 }
+        store.update { $0.defaultGeometry.maxWidth = 400 }
         store.enterEditMode()
-        store.update { $0.maxWidth = 600 }
+        store.update { $0.defaultGeometry.maxWidth = 600 }
         store.commitEdit()
-        XCTAssertEqual(store.customization.maxWidth, 600)
+        XCTAssertEqual(store.customization.defaultGeometry.maxWidth, 600)
         XCTAssertFalse(store.isEditing)
     }
 

--- a/ClaudeIslandTests/NotchCustomizationTests.swift
+++ b/ClaudeIslandTests/NotchCustomizationTests.swift
@@ -27,8 +27,8 @@ final class NotchCustomizationTests: XCTestCase {
         XCTAssertEqual(c.fontScale, .default)
         XCTAssertTrue(c.showBuddy)
         XCTAssertTrue(c.showUsageBar)
-        XCTAssertEqual(c.maxWidth, 440)
-        XCTAssertEqual(c.horizontalOffset, 0)
+        XCTAssertEqual(c.defaultGeometry.maxWidth, 440)
+        XCTAssertEqual(c.defaultGeometry.horizontalOffset, 0)
         XCTAssertEqual(c.hardwareNotchMode, .auto)
     }
 
@@ -40,8 +40,8 @@ final class NotchCustomizationTests: XCTestCase {
         original.fontScale = .large
         original.showBuddy = false
         original.showUsageBar = false
-        original.maxWidth = 520
-        original.horizontalOffset = -42
+        original.defaultGeometry.maxWidth = 520
+        original.defaultGeometry.horizontalOffset = -42
         original.hardwareNotchMode = .forceVirtual
 
         let data = try JSONEncoder().encode(original)
@@ -63,8 +63,8 @@ final class NotchCustomizationTests: XCTestCase {
         XCTAssertEqual(decoded.fontScale, .default)
         XCTAssertTrue(decoded.showBuddy)
         XCTAssertTrue(decoded.showUsageBar)
-        XCTAssertEqual(decoded.maxWidth, 440)
-        XCTAssertEqual(decoded.horizontalOffset, 0)
+        XCTAssertEqual(decoded.defaultGeometry.maxWidth, 440)
+        XCTAssertEqual(decoded.defaultGeometry.horizontalOffset, 0)
         XCTAssertEqual(decoded.hardwareNotchMode, .auto)
     }
 
@@ -118,5 +118,60 @@ final class NotchCustomizationTests: XCTestCase {
         )
         XCTAssertEqual(auto, .auto)
         XCTAssertEqual(virt, .forceVirtual)
+    }
+
+    // MARK: - ScreenGeometry
+
+    func test_screenGeometry_defaultValues() {
+        let geo = ScreenGeometry.default
+        XCTAssertEqual(geo.maxWidth, 440)
+        XCTAssertEqual(geo.horizontalOffset, 0)
+        XCTAssertEqual(geo.notchHeight, 38)
+    }
+
+    func test_screenGeometry_codableRoundtrip() throws {
+        var geo = ScreenGeometry.default
+        geo.maxWidth = 520
+        geo.horizontalOffset = -42
+        geo.notchHeight = 50
+        let data = try JSONEncoder().encode(geo)
+        let decoded = try JSONDecoder().decode(ScreenGeometry.self, from: data)
+        XCTAssertEqual(decoded, geo)
+    }
+
+    // MARK: - Per-screen geometry
+
+    func test_geometry_forUnknownScreen_returnsDefault() {
+        let c = NotchCustomization.default
+        let geo = c.geometry(for: "999")
+        XCTAssertEqual(geo, ScreenGeometry.default)
+    }
+
+    func test_updateGeometry_storesPerScreen() {
+        var c = NotchCustomization.default
+        c.updateGeometry(for: "42") { $0.notchHeight = 60 }
+        XCTAssertEqual(c.geometry(for: "42").notchHeight, 60)
+        XCTAssertEqual(c.geometry(for: "99").notchHeight, 38)
+    }
+
+    func test_codable_legacyMigration_topLevelFieldsToDefaultGeometry() throws {
+        let legacy = """
+        {"theme":"classic","fontScale":"default","showBuddy":true,"showUsageBar":true,
+         "maxWidth":520,"horizontalOffset":-30,"hardwareNotchMode":"auto"}
+        """
+        let decoded = try JSONDecoder().decode(NotchCustomization.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded.defaultGeometry.maxWidth, 520)
+        XCTAssertEqual(decoded.defaultGeometry.horizontalOffset, -30)
+        XCTAssertEqual(decoded.defaultGeometry.notchHeight, 38)
+        XCTAssertTrue(decoded.screenGeometries.isEmpty)
+    }
+
+    func test_codable_newFormat_roundtrip() throws {
+        var original = NotchCustomization.default
+        original.updateGeometry(for: "42") { $0.maxWidth = 600; $0.notchHeight = 50 }
+        original.updateGeometry(for: "99") { $0.horizontalOffset = 20 }
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(NotchCustomization.self, from: data)
+        XCTAssertEqual(decoded, original)
     }
 }

--- a/docs/superpowers/plans/2026-04-10-per-screen-notch-height.md
+++ b/docs/superpowers/plans/2026-04-10-per-screen-notch-height.md
@@ -1,0 +1,789 @@
+# Per-Screen Notch Height Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to customize the closed-state notch height on external displays, with all geometry settings (width, offset, height) stored per-screen.
+
+**Architecture:** Extract geometry fields from `NotchCustomization` into a new `ScreenGeometry` struct stored in a `[String: ScreenGeometry]` dictionary keyed by `CGDirectDisplayID`. Add `persistentID` to `NSScreen`. Add ▲▼ height controls to Live Edit overlay. Appearance settings remain global.
+
+**Tech Stack:** Swift, SwiftUI, AppKit, Combine, UserDefaults (JSON-encoded)
+
+---
+
+### Task 1: Add `ScreenGeometry` struct and refactor `NotchCustomization` model
+
+**Files:**
+- Modify: `ClaudeIsland/Models/NotchCustomization.swift`
+
+- [ ] **Step 1: Write failing tests for the new model**
+
+Add to `ClaudeIslandTests/NotchCustomizationTests.swift`:
+
+```swift
+// MARK: - ScreenGeometry
+
+func test_screenGeometry_defaultValues() {
+    let geo = ScreenGeometry.default
+    XCTAssertEqual(geo.maxWidth, 440)
+    XCTAssertEqual(geo.horizontalOffset, 0)
+    XCTAssertEqual(geo.notchHeight, 38)
+}
+
+func test_screenGeometry_codableRoundtrip() throws {
+    var geo = ScreenGeometry.default
+    geo.maxWidth = 520
+    geo.horizontalOffset = -42
+    geo.notchHeight = 50
+    let data = try JSONEncoder().encode(geo)
+    let decoded = try JSONDecoder().decode(ScreenGeometry.self, from: data)
+    XCTAssertEqual(decoded, geo)
+}
+
+// MARK: - Per-screen geometry
+
+func test_geometry_forUnknownScreen_returnsDefault() {
+    let c = NotchCustomization.default
+    let geo = c.geometry(for: "999")
+    XCTAssertEqual(geo, ScreenGeometry.default)
+}
+
+func test_updateGeometry_storesPerScreen() {
+    var c = NotchCustomization.default
+    c.updateGeometry(for: "42") { $0.notchHeight = 60 }
+    XCTAssertEqual(c.geometry(for: "42").notchHeight, 60)
+    // Other screens still get default
+    XCTAssertEqual(c.geometry(for: "99").notchHeight, 38)
+}
+
+func test_codable_legacyMigration_topLevelFieldsToDefaultGeometry() throws {
+    // Simulate a legacy v1 blob with top-level maxWidth + horizontalOffset
+    let legacy = """
+    {"theme":"classic","fontScale":"default","showBuddy":true,"showUsageBar":true,
+     "maxWidth":520,"horizontalOffset":-30,"hardwareNotchMode":"auto"}
+    """
+    let decoded = try JSONDecoder().decode(NotchCustomization.self, from: Data(legacy.utf8))
+    XCTAssertEqual(decoded.defaultGeometry.maxWidth, 520)
+    XCTAssertEqual(decoded.defaultGeometry.horizontalOffset, -30)
+    XCTAssertEqual(decoded.defaultGeometry.notchHeight, 38)
+    // screenGeometries should be empty (no per-screen data in legacy)
+    XCTAssertTrue(decoded.screenGeometries.isEmpty)
+}
+
+func test_codable_newFormat_roundtrip() throws {
+    var original = NotchCustomization.default
+    original.updateGeometry(for: "42") { $0.maxWidth = 600; $0.notchHeight = 50 }
+    original.updateGeometry(for: "99") { $0.horizontalOffset = 20 }
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(NotchCustomization.self, from: data)
+    XCTAssertEqual(decoded, original)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/NotchCustomizationTests 2>&1 | tail -20`
+Expected: Compilation errors — `ScreenGeometry` not defined.
+
+- [ ] **Step 3: Implement `ScreenGeometry` and refactor `NotchCustomization`**
+
+In `ClaudeIsland/Models/NotchCustomization.swift`, add `ScreenGeometry` before `NotchCustomization`:
+
+```swift
+/// Per-screen geometry settings. Keyed by screen's CGDirectDisplayID
+/// in NotchCustomization.screenGeometries.
+struct ScreenGeometry: Codable, Equatable {
+    var maxWidth: CGFloat = 440
+    var horizontalOffset: CGFloat = 0
+    var notchHeight: CGFloat = 38
+
+    static let `default` = ScreenGeometry()
+}
+```
+
+Then refactor `NotchCustomization`:
+
+1. **Remove** the `maxWidth` and `horizontalOffset` stored properties.
+2. **Remove** them from the `init(...)` parameter list.
+3. **Add** these new stored properties:
+
+```swift
+    // Geometry (per-screen)
+    var screenGeometries: [String: ScreenGeometry] = [:]
+    var defaultGeometry: ScreenGeometry = .init()
+```
+
+4. **Add** convenience accessors:
+
+```swift
+    func geometry(for screenID: String) -> ScreenGeometry {
+        screenGeometries[screenID] ?? defaultGeometry
+    }
+
+    mutating func updateGeometry(for screenID: String, _ body: (inout ScreenGeometry) -> Void) {
+        var geo = geometry(for: screenID)
+        body(&geo)
+        screenGeometries[screenID] = geo
+    }
+```
+
+5. **Update** `CodingKeys` — remove `maxWidth`, `horizontalOffset`; add `screenGeometries`, `defaultGeometry`.
+
+6. **Update** `init(from decoder:)` for forward-compat + legacy migration:
+
+```swift
+    private enum CodingKeys: String, CodingKey {
+        case theme, fontScale, showBuddy, showUsageBar,
+             hardwareNotchMode, screenGeometries, defaultGeometry,
+             maxWidth, horizontalOffset // legacy keys for migration
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.theme = try c.decodeIfPresent(NotchThemeID.self, forKey: .theme) ?? .classic
+        self.fontScale = try c.decodeIfPresent(FontScale.self, forKey: .fontScale) ?? .default
+        self.showBuddy = try c.decodeIfPresent(Bool.self, forKey: .showBuddy) ?? true
+        self.showUsageBar = try c.decodeIfPresent(Bool.self, forKey: .showUsageBar) ?? true
+        self.hardwareNotchMode = try c.decodeIfPresent(HardwareNotchMode.self, forKey: .hardwareNotchMode) ?? .auto
+        self.screenGeometries = try c.decodeIfPresent([String: ScreenGeometry].self, forKey: .screenGeometries) ?? [:]
+        self.defaultGeometry = try c.decodeIfPresent(ScreenGeometry.self, forKey: .defaultGeometry) ?? .init()
+
+        // Legacy migration: old top-level geometry fields → defaultGeometry
+        if let legacyWidth = try c.decodeIfPresent(CGFloat.self, forKey: .maxWidth) {
+            self.defaultGeometry.maxWidth = legacyWidth
+        }
+        if let legacyOffset = try c.decodeIfPresent(CGFloat.self, forKey: .horizontalOffset) {
+            self.defaultGeometry.horizontalOffset = legacyOffset
+        }
+    }
+
+    // Only encode new fields (legacy keys are never written back)
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(theme, forKey: .theme)
+        try c.encode(fontScale, forKey: .fontScale)
+        try c.encode(showBuddy, forKey: .showBuddy)
+        try c.encode(showUsageBar, forKey: .showUsageBar)
+        try c.encode(hardwareNotchMode, forKey: .hardwareNotchMode)
+        try c.encode(screenGeometries, forKey: .screenGeometries)
+        try c.encode(defaultGeometry, forKey: .defaultGeometry)
+    }
+```
+
+- [ ] **Step 4: Fix existing tests that reference old `maxWidth` / `horizontalOffset` top-level properties**
+
+In `NotchCustomizationTests.swift`:
+- `test_default_hasExpectedValues`: Replace `c.maxWidth` → `c.defaultGeometry.maxWidth`, `c.horizontalOffset` → `c.defaultGeometry.horizontalOffset`.
+- `test_codable_roundtripPreservesAllFields`: Replace `original.maxWidth = 520` → `original.defaultGeometry.maxWidth = 520`, `original.horizontalOffset = -42` → `original.defaultGeometry.horizontalOffset = -42`.
+- `test_codable_forwardCompat_missingFieldsUseDefaults`: Replace `decoded.maxWidth` → `decoded.defaultGeometry.maxWidth`, `decoded.horizontalOffset` → `decoded.defaultGeometry.horizontalOffset`.
+
+In `NotchCustomizationStoreTests.swift`:
+- `test_init_withExistingV1Key_loadsIt`: Replace `persisted.maxWidth = 520` → `persisted.defaultGeometry.maxWidth = 520`, `store.customization.maxWidth` → `store.customization.defaultGeometry.maxWidth`.
+- `test_cancelEdit_rollsBackToSnapshot`: Replace all `$0.maxWidth` → `$0.defaultGeometry.maxWidth`, `store.customization.maxWidth` → `store.customization.defaultGeometry.maxWidth`.
+- `test_commitEdit_keepsChanges`: Same pattern.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/NotchCustomizationTests -only-testing ClaudeIslandTests/NotchCustomizationStoreTests 2>&1 | tail -20`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ClaudeIsland/Models/NotchCustomization.swift ClaudeIslandTests/NotchCustomizationTests.swift ClaudeIslandTests/NotchCustomizationStoreTests.swift
+git commit -m "feat: add ScreenGeometry struct, per-screen geometry storage with legacy migration"
+```
+
+---
+
+### Task 2: Add `NSScreen.persistentID` and height clamping
+
+**Files:**
+- Modify: `ClaudeIsland/Core/Ext+NSScreen.swift`
+- Modify: `ClaudeIsland/Core/NotchHardwareDetector.swift`
+- Modify: `ClaudeIslandTests/AutoWidthTests.swift`
+
+- [ ] **Step 1: Write failing tests for height clamping**
+
+Add to `ClaudeIslandTests/AutoWidthTests.swift`:
+
+```swift
+// MARK: - clampedHeight
+
+func test_clampedHeight_withinRange_passesThrough() {
+    XCTAssertEqual(NotchHardwareDetector.clampedHeight(50), 50)
+}
+
+func test_clampedHeight_belowMin_returnsMin() {
+    XCTAssertEqual(NotchHardwareDetector.clampedHeight(5), NotchHardwareDetector.minNotchHeight)
+}
+
+func test_clampedHeight_aboveMax_returnsMax() {
+    XCTAssertEqual(NotchHardwareDetector.clampedHeight(200), NotchHardwareDetector.maxNotchHeight)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/AutoWidthTests 2>&1 | tail -20`
+Expected: Compilation errors — `clampedHeight`, `minNotchHeight`, `maxNotchHeight` not defined.
+
+- [ ] **Step 3: Add `persistentID` to NSScreen**
+
+In `ClaudeIsland/Core/Ext+NSScreen.swift`, add after the `hasPhysicalNotch` property:
+
+```swift
+    /// Stable string identifier for per-screen settings persistence.
+    /// Derived from CGDirectDisplayID.
+    var persistentID: String {
+        let id = (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) ?? 0
+        return String(id)
+    }
+```
+
+- [ ] **Step 4: Add height clamping to NotchHardwareDetector**
+
+In `ClaudeIsland/Core/NotchHardwareDetector.swift`, add after the `minIdleWidth` constant:
+
+```swift
+    // MARK: - Notch height clamp
+
+    /// Minimum custom notch height — ensures the notch is always visible.
+    static let minNotchHeight: CGFloat = 20
+
+    /// Maximum custom notch height — prevents excessive screen coverage.
+    static let maxNotchHeight: CGFloat = 80
+
+    /// Clamp a user-provided notch height to the valid range. Pure function.
+    static func clampedHeight(_ height: CGFloat) -> CGFloat {
+        max(minNotchHeight, min(height, maxNotchHeight))
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/AutoWidthTests 2>&1 | tail -20`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ClaudeIsland/Core/Ext+NSScreen.swift ClaudeIsland/Core/NotchHardwareDetector.swift ClaudeIslandTests/AutoWidthTests.swift
+git commit -m "feat: add NSScreen.persistentID and notch height clamping"
+```
+
+---
+
+### Task 3: Add `updateGeometry` to `NotchCustomizationStore`
+
+**Files:**
+- Modify: `ClaudeIsland/Services/State/NotchCustomizationStore.swift`
+- Modify: `ClaudeIslandTests/NotchCustomizationStoreTests.swift`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `ClaudeIslandTests/NotchCustomizationStoreTests.swift`:
+
+```swift
+func test_updateGeometry_mutatesAndPersists() throws {
+    let store = NotchCustomizationStore()
+    store.updateGeometry(for: "42") { $0.notchHeight = 55 }
+
+    XCTAssertEqual(store.customization.geometry(for: "42").notchHeight, 55)
+
+    let data = try XCTUnwrap(UserDefaults.standard.data(forKey: v1Key))
+    let decoded = try JSONDecoder().decode(NotchCustomization.self, from: data)
+    XCTAssertEqual(decoded.geometry(for: "42").notchHeight, 55)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/NotchCustomizationStoreTests/test_updateGeometry_mutatesAndPersists 2>&1 | tail -20`
+Expected: Compilation error — `updateGeometry(for:_:)` not defined on store.
+
+- [ ] **Step 3: Add `updateGeometry` method**
+
+In `ClaudeIsland/Services/State/NotchCustomizationStore.swift`, add after the existing `update(_:)` method:
+
+```swift
+    /// Convenience for updating geometry of a specific screen.
+    func updateGeometry(for screenID: String, _ mutation: (inout ScreenGeometry) -> Void) {
+        update { $0.updateGeometry(for: screenID, mutation) }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland -only-testing ClaudeIslandTests/NotchCustomizationStoreTests 2>&1 | tail -20`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ClaudeIsland/Services/State/NotchCustomizationStore.swift ClaudeIslandTests/NotchCustomizationStoreTests.swift
+git commit -m "feat: add updateGeometry(for:) convenience on NotchCustomizationStore"
+```
+
+---
+
+### Task 4: Wire per-screen geometry into `NotchWindowController` and `NotchViewModel`
+
+**Files:**
+- Modify: `ClaudeIsland/UI/Window/NotchWindowController.swift`
+- Modify: `ClaudeIsland/Core/NotchViewModel.swift`
+
+- [ ] **Step 1: Add `screenID` to `NotchWindowController`**
+
+In `NotchWindowController.swift`, add a stored property after `private let screen: NSScreen`:
+
+```swift
+    let screenID: String
+```
+
+In `init(screen:)`, after `self.screen = screen`, add:
+
+```swift
+        self.screenID = screen.persistentID
+```
+
+- [ ] **Step 2: Update `applyGeometryFromStore()` to use per-screen geometry**
+
+Replace the body of `applyGeometryFromStore()`:
+
+```swift
+    @MainActor
+    func applyGeometryFromStore() {
+        let store = NotchCustomizationStore.shared
+        let geo = store.customization.geometry(for: screenID)
+        let window = self.window
+
+        guard let window else { return }
+        let activeScreen = window.screen ?? self.screen
+        let screenFrame = activeScreen.frame
+
+        let runtimeWidth = NotchHardwareDetector.clampedWidth(
+            measuredContentWidth: geo.maxWidth,
+            maxWidth: geo.maxWidth
+        )
+        let clampedOffset = NotchHardwareDetector.clampedHorizontalOffset(
+            storedOffset: geo.horizontalOffset,
+            runtimeWidth: runtimeWidth,
+            screenWidth: screenFrame.width
+        )
+        let baseX = (screenFrame.width - runtimeWidth) / 2
+        let finalX = screenFrame.origin.x + baseX + clampedOffset
+
+        _ = (finalX, runtimeWidth)
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.35
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            window.animator().setFrame(window.frame, display: true)
+        }
+    }
+```
+
+- [ ] **Step 3: Pass `screenID` into Live Edit overlay**
+
+In `enterLiveEditMode()`, update the `NotchLiveEditOverlay` initializer to pass the screenID:
+
+```swift
+        let overlay = NotchLiveEditOverlay(
+            screenID: screenID,
+            screenProvider: { activeScreen },
+            onExit: { [weak self] in
+                self?.exitLiveEditMode()
+            }
+        )
+```
+
+- [ ] **Step 4: Update `NotchViewModel` to accept `screenID`**
+
+In `NotchViewModel.swift`:
+
+Add a stored property:
+
+```swift
+    let screenID: String
+```
+
+Update `init` signature and body:
+
+```swift
+    init(deviceNotchRect: CGRect, screenRect: CGRect, windowHeight: CGFloat, hasPhysicalNotch: Bool, screenID: String) {
+        self.screenID = screenID
+        self.geometry = NotchGeometry(
+            deviceNotchRect: deviceNotchRect,
+            screenRect: screenRect,
+            windowHeight: windowHeight
+        )
+        self.hasPhysicalNotch = hasPhysicalNotch
+        setupEventHandlers()
+        observeSelectors()
+    }
+```
+
+Update `currentHorizontalOffset` to read per-screen:
+
+```swift
+    private var currentHorizontalOffset: CGFloat {
+        let geo = NotchCustomizationStore.shared.customization.geometry(for: screenID)
+        let runtime: CGFloat = status == .opened ? openedSize.width : (geometry.deviceNotchRect.width + currentExpansionWidth)
+        return NotchHardwareDetector.clampedHorizontalOffset(
+            storedOffset: geo.horizontalOffset,
+            runtimeWidth: runtime,
+            screenWidth: geometry.screenRect.width
+        )
+    }
+```
+
+- [ ] **Step 5: Update `NotchWindowController.init` to pass `screenID`**
+
+In `NotchWindowController.swift`, update the `NotchViewModel` creation:
+
+```swift
+        self.viewModel = NotchViewModel(
+            deviceNotchRect: deviceNotchRect,
+            screenRect: screenFrame,
+            windowHeight: windowHeight,
+            hasPhysicalNotch: screen.hasPhysicalNotch,
+            screenID: screen.persistentID
+        )
+```
+
+- [ ] **Step 6: Build to verify compilation**
+
+Run: `xcodebuild build -project ClaudeIsland.xcodeproj -scheme ClaudeIsland 2>&1 | tail -20`
+Expected: Build succeeds (ignoring NotchLiveEditOverlay signature mismatch — fixed in Task 6).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ClaudeIsland/UI/Window/NotchWindowController.swift ClaudeIsland/Core/NotchViewModel.swift
+git commit -m "feat: wire per-screen geometry into window controller and view model"
+```
+
+---
+
+### Task 5: Update `NotchView` to read per-screen geometry
+
+**Files:**
+- Modify: `ClaudeIsland/UI/Views/NotchView.swift`
+
+- [ ] **Step 1: Update `closedNotchSize` to use per-screen `notchHeight`**
+
+The `closedNotchSize` computed property currently reads `viewModel.deviceNotchRect.height`. Change it to use the per-screen configured height for non-hardware-notch screens:
+
+```swift
+    private var closedNotchSize: CGSize {
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        let height: CGFloat
+        if viewModel.hasPhysicalNotch {
+            height = viewModel.deviceNotchRect.height
+        } else {
+            height = NotchHardwareDetector.clampedHeight(geo.notchHeight)
+        }
+        return CGSize(
+            width: viewModel.deviceNotchRect.width,
+            height: height
+        )
+    }
+```
+
+- [ ] **Step 2: Update `expansionWidth` to use per-screen `maxWidth`**
+
+```swift
+    private var expansionWidth: CGFloat {
+        guard hasActiveSessions else { return 0 }
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        let userMax = geo.maxWidth
+        let userExpansion = max(0, userMax - closedNotchSize.width)
+        if compactCollapsed {
+            return min(100, userExpansion)
+        }
+        return userExpansion
+    }
+```
+
+- [ ] **Step 3: Update `clampedHorizontalOffset` to use per-screen offset**
+
+```swift
+    private var clampedHorizontalOffset: CGFloat {
+        let geo = notchStore.customization.geometry(for: viewModel.screenID)
+        return NotchHardwareDetector.clampedHorizontalOffset(
+            storedOffset: geo.horizontalOffset,
+            runtimeWidth: viewModel.status == .opened ? notchSize.width : closedContentWidth,
+            screenWidth: viewModel.screenRect.width
+        )
+    }
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `xcodebuild build -project ClaudeIsland.xcodeproj -scheme ClaudeIsland 2>&1 | tail -20`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ClaudeIsland/UI/Views/NotchView.swift
+git commit -m "feat: NotchView reads per-screen geometry for height, width, and offset"
+```
+
+---
+
+### Task 6: Update Live Edit overlay with height controls and per-screen writes
+
+**Files:**
+- Modify: `ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift`
+- Modify: `ClaudeIsland/Core/Localization.swift`
+
+- [ ] **Step 1: Add `screenID` property to `NotchLiveEditOverlay`**
+
+Add a stored property at the top of the struct, before `@ObservedObject`:
+
+```swift
+    let screenID: String
+```
+
+- [ ] **Step 2: Update `visibleNotchHeight` to read from per-screen config**
+
+Replace the hardcoded `visibleNotchHeight` constant with a computed property:
+
+```swift
+    private var visibleNotchHeight: CGFloat {
+        if hasHardwareNotch {
+            return 38
+        }
+        let geo = store.customization.geometry(for: screenID)
+        return NotchHardwareDetector.clampedHeight(geo.notchHeight)
+    }
+```
+
+- [ ] **Step 3: Update `userExpansion` and `readoutText` to read per-screen**
+
+```swift
+    private var userExpansion: CGFloat {
+        let geo = store.customization.geometry(for: screenID)
+        return max(0, geo.maxWidth - baseNotchWidth)
+    }
+```
+
+Update `readoutText` to include height:
+
+```swift
+    private var readoutText: String {
+        let geo = store.customization.geometry(for: screenID)
+        let width = Int(geo.maxWidth.rounded())
+        let height = Int(visibleNotchHeight.rounded())
+        let offset = Int(geo.horizontalOffset.rounded())
+        let offsetSign = offset > 0 ? "+\(offset)" : "\(offset)"
+        return "W \(width)pt   H \(height)pt   X \(offsetSign)pt"
+    }
+```
+
+- [ ] **Step 4: Add ▲▼ height arrow buttons to the body**
+
+In the `ZStack` of `body`, after the existing ◀ ▶ arrow buttons (items 4), add:
+
+```swift
+                // 4b. Height arrow buttons (▲ ▼) above/below the notch.
+                // Disabled when screen has a hardware notch.
+                heightArrowButton(direction: +1, label: "Increase notch height")
+                    .position(x: notchCenterX, y: -10)
+
+                heightArrowButton(direction: -1, label: "Decrease notch height")
+                    .position(x: notchCenterX, y: visibleNotchHeight + 14)
+```
+
+- [ ] **Step 5: Implement `heightArrowButton` and `applyHeightStep`**
+
+Add after the existing `arrowButton(direction:label:)` method:
+
+```swift
+    private func heightArrowButton(direction: Int, label: String) -> some View {
+        Button {
+            applyHeightStep(direction: direction)
+        } label: {
+            Image(systemName: direction > 0 ? "chevron.up" : "chevron.down")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundColor(hasHardwareNotch ? .white.opacity(0.35) : .black)
+                .frame(width: 32, height: 32)
+                .background(Circle().fill(hasHardwareNotch ? Color.black.opacity(0.5) : neonGreen))
+                .shadow(color: hasHardwareNotch ? .clear : neonGreen.opacity(0.45), radius: 6)
+        }
+        .buttonStyle(.plain)
+        .disabled(hasHardwareNotch)
+        .accessibilityLabel(label)
+        .accessibilityHint(hasHardwareNotch ? "Disabled: hardware notch height is fixed" : "Hold Command for a larger step, hold Option for a finer step.")
+    }
+
+    private func applyHeightStep(direction: Int) {
+        let flags = NSEvent.modifierFlags
+        let step: CGFloat
+        if flags.contains(.command) {
+            step = 10
+        } else if flags.contains(.option) {
+            step = 1
+        } else {
+            step = 4
+        }
+        store.updateGeometry(for: screenID) { geo in
+            geo.notchHeight = NotchHardwareDetector.clampedHeight(
+                geo.notchHeight + CGFloat(direction) * step
+            )
+        }
+    }
+```
+
+- [ ] **Step 6: Update existing width arrow and drag to write per-screen**
+
+Update `applyArrowStep(direction:)`:
+
+```swift
+    private func applyArrowStep(direction: Int) {
+        let flags = NSEvent.modifierFlags
+        let step: CGFloat
+        if flags.contains(.command) {
+            step = 10
+        } else if flags.contains(.option) {
+            step = 1
+        } else {
+            step = 4
+        }
+        store.updateGeometry(for: screenID) { geo in
+            geo.maxWidth = max(
+                NotchHardwareDetector.minIdleWidth,
+                geo.maxWidth + CGFloat(direction) * step
+            )
+        }
+    }
+```
+
+Update the drag gesture `.onChanged` closure:
+
+```swift
+                            .onChanged { value in
+                                if dragStartOffset == nil {
+                                    dragStartOffset = store.customization.geometry(for: screenID).horizontalOffset
+                                }
+                                let start = dragStartOffset ?? 0
+                                store.updateGeometry(for: screenID) { geo in
+                                    geo.horizontalOffset = start + value.translation.width
+                                }
+                            }
+```
+
+Update `applyNotchPreset()`:
+
+```swift
+    private func applyNotchPreset() {
+        let width = NotchHardwareDetector.hardwareNotchWidth(
+            on: screenProvider(),
+            mode: store.customization.hardwareNotchMode
+        )
+        guard width > 0 else { return }
+        store.updateGeometry(for: screenID) { geo in
+            geo.maxWidth = width + 20
+            geo.horizontalOffset = 0
+        }
+        withAnimation(.easeIn(duration: 0.2)) {
+            presetMarkerVisible = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+            withAnimation(.easeOut(duration: 0.2)) {
+                presetMarkerVisible = false
+            }
+        }
+    }
+```
+
+Update the Reset button action:
+
+```swift
+                        actionButton(
+                            title: L10n.notchEditReset,
+                            icon: "arrow.counterclockwise",
+                            enabled: true
+                        ) {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                store.updateGeometry(for: screenID) { geo in
+                                    geo.maxWidth = ScreenGeometry.default.maxWidth
+                                    geo.horizontalOffset = ScreenGeometry.default.horizontalOffset
+                                    geo.notchHeight = ScreenGeometry.default.notchHeight
+                                }
+                                subMode = .resize
+                                dragStartOffset = nil
+                            }
+                        }
+```
+
+- [ ] **Step 7: Build to verify compilation**
+
+Run: `xcodebuild build -project ClaudeIsland.xcodeproj -scheme ClaudeIsland 2>&1 | tail -20`
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ClaudeIsland/UI/Views/NotchLiveEditOverlay.swift
+git commit -m "feat: add height ▲▼ controls to Live Edit, convert all geometry ops to per-screen"
+```
+
+---
+
+### Task 7: Fix remaining compile errors across the codebase
+
+**Files:**
+- Any file that still references `customization.maxWidth` or `customization.horizontalOffset` directly
+
+- [ ] **Step 1: Search for remaining references to old top-level geometry fields**
+
+Run: `grep -rn 'customization\.maxWidth\|customization\.horizontalOffset\|\.maxWidth\b.*=\|\.horizontalOffset\b.*=' ClaudeIsland/ --include='*.swift' | grep -v 'ScreenGeometry\|defaultGeometry\|screenGeometries'`
+
+This will find any remaining direct references to the old fields.
+
+- [ ] **Step 2: Fix each reference**
+
+For each hit, determine the screenID context and convert to per-screen access:
+- If in a view/controller that has access to `screenID` → use `customization.geometry(for: screenID).maxWidth`
+- If in a context without screenID → determine the correct screen and pass it through
+
+Common patterns:
+- `store.customization.maxWidth` → `store.customization.geometry(for: screenID).maxWidth`
+- `$0.maxWidth = ...` → use `store.updateGeometry(for: screenID) { $0.maxWidth = ... }`
+
+- [ ] **Step 3: Build to verify clean compilation**
+
+Run: `xcodebuild build -project ClaudeIsland.xcodeproj -scheme ClaudeIsland 2>&1 | tail -20`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "fix: resolve remaining references to old top-level geometry fields"
+```
+
+---
+
+### Task 8: Run all tests and verify
+
+**Files:**
+- All test files
+
+- [ ] **Step 1: Run all tests**
+
+Run: `xcodebuild test -project ClaudeIsland.xcodeproj -scheme ClaudeIsland 2>&1 | tail -40`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Fix any failures**
+
+If any tests fail, fix them by updating to use per-screen geometry access patterns.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -u
+git commit -m "test: all tests pass with per-screen geometry model"
+```

--- a/docs/superpowers/specs/2026-04-10-per-screen-notch-height-design.md
+++ b/docs/superpowers/specs/2026-04-10-per-screen-notch-height-design.md
@@ -1,0 +1,160 @@
+# Per-Screen Notch Height Customization
+
+## Problem
+
+External 4K displays have no hardware notch. The app currently hardcodes the closed-state notch height to 38pt for all non-notch screens. Users want to adjust this height. Additionally, all geometry settings (width, offset) are global — they should be per-screen so each display can have its own configuration.
+
+## Solution
+
+1. Extract geometry properties (`maxWidth`, `horizontalOffset`, new `notchHeight`) into a `ScreenGeometry` struct stored per-screen in a dictionary keyed by `CGDirectDisplayID`.
+2. Add height adjustment controls (▲▼ arrows) to the existing Live Edit mode.
+3. Appearance settings (theme, font, visibility toggles, hardware mode) remain global.
+
+## Data Model
+
+### New: `ScreenGeometry`
+
+```swift
+struct ScreenGeometry: Codable, Equatable {
+    var maxWidth: CGFloat = 440
+    var horizontalOffset: CGFloat = 0
+    var notchHeight: CGFloat = 38
+
+    static let `default` = ScreenGeometry()
+}
+```
+
+### Modified: `NotchCustomization`
+
+```swift
+struct NotchCustomization: Codable, Equatable {
+    // Appearance (global)
+    var theme: NotchThemeID = .classic
+    var fontScale: FontScale = .default
+    var showBuddy: Bool = true
+    var showUsageBar: Bool = true
+    var hardwareNotchMode: HardwareNotchMode = .auto
+
+    // Geometry (per-screen)
+    var screenGeometries: [String: ScreenGeometry] = [:]
+    var defaultGeometry: ScreenGeometry = .init()
+
+    func geometry(for screenID: String) -> ScreenGeometry {
+        screenGeometries[screenID] ?? defaultGeometry
+    }
+
+    mutating func updateGeometry(for screenID: String, _ body: (inout ScreenGeometry) -> Void) {
+        var geo = geometry(for: screenID)
+        body(&geo)
+        screenGeometries[screenID] = geo
+    }
+}
+```
+
+Remove the old top-level `maxWidth` and `horizontalOffset` properties.
+
+### Screen ID
+
+```swift
+extension NSScreen {
+    var persistentID: String {
+        let id = (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) ?? 0
+        return String(id)
+    }
+}
+```
+
+### Migration (v1 compatible)
+
+In `NotchCustomization.init(from:)`:
+- If legacy top-level `maxWidth` or `horizontalOffset` fields exist, read them into `defaultGeometry`.
+- New fields (`screenGeometries`, `defaultGeometry`) decode with defaults when absent.
+- UserDefaults key stays `"notchCustomization.v1"` — no key bump needed.
+- On next save, only new fields are encoded; legacy fields are dropped.
+
+## Geometry Calculation
+
+### `NotchGeometry`
+
+Add `customNotchHeight: CGFloat` field. Methods that reference the notch height (`collapsedScreenRect`, `notchScreenRect`, `isPointInNotch`) use `customNotchHeight` instead of `deviceNotchRect.height` for the collapsed state.
+
+### `NotchHardwareDetector`
+
+New constants and function:
+
+```swift
+static let minNotchHeight: CGFloat = 20
+static let maxNotchHeight: CGFloat = 80
+
+static func clampedHeight(_ height: CGFloat) -> CGFloat {
+    max(minNotchHeight, min(height, maxNotchHeight))
+}
+```
+
+### `NotchView`
+
+`closedNotchSize.height` reads from `ScreenGeometry.notchHeight` (via `NotchGeometry.customNotchHeight`) instead of `deviceNotchRect.height`.
+
+### Hardware notch override
+
+When the screen has a physical notch (`safeAreaInsets.top > 0`), `customNotchHeight` is ignored — the system value is used. Height controls are disabled in Live Edit for such screens.
+
+## Live Edit Interaction
+
+### Height controls
+
+- ▲▼ arrow buttons positioned above/below the notch (symmetric with existing ◀▶ width arrows).
+- Step sizes match width controls:
+  - Default: ±4pt
+  - `⌘`: ±10pt
+  - `⌥`: ±1pt
+- Clamped to `[20, 80]` range.
+- Disabled when screen has a hardware notch.
+
+### Numeric readout
+
+Updated from `"W 440pt  X +12pt"` to:
+
+```
+W 440pt   H 38pt   X +12pt
+```
+
+### Per-screen binding
+
+On entering Live Edit, the current screen's `persistentID` is captured. All geometry adjustments (width, height, offset) read/write the `ScreenGeometry` for that screen ID.
+
+## Store Layer
+
+### `NotchCustomizationStore`
+
+- Add convenience method: `updateGeometry(for screenID: String, _ body: (inout ScreenGeometry) -> Void)`.
+- Live Edit snapshot/restore unchanged — `editDraftOrigin` snapshots the entire `NotchCustomization` (all screens), cancel restores the whole thing.
+
+## Window Controller
+
+### `NotchWindowController`
+
+- Stores the screen's `persistentID` at init time.
+- `applyGeometryFromStore()` reads per-screen geometry via `customization.geometry(for: screenID)`.
+- Passes `customNotchHeight` when constructing `NotchGeometry` / `NotchViewModel`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `NotchCustomization.swift` | Add `ScreenGeometry`, replace `maxWidth`/`horizontalOffset` with `screenGeometries`/`defaultGeometry`, migration decoding |
+| `Ext+NSScreen.swift` | Add `persistentID` |
+| `NotchCustomizationStore.swift` | Add `updateGeometry(for:_:)` |
+| `NotchGeometry.swift` | Add `customNotchHeight`, use it in collapsed-state methods |
+| `NotchHardwareDetector.swift` | Add height constants + `clampedHeight()` |
+| `NotchWindowController.swift` | Store screenID, read per-screen geometry |
+| `NotchView.swift` | `closedNotchSize` height from config, per-screen reads |
+| `NotchLiveEditOverlay.swift` | ▲▼ buttons, `H xxpt` readout, per-screen writes |
+| `NotchViewModel.swift` | Pass `customNotchHeight` to geometry |
+| Tests | Adapt `NotchCustomizationTests`, `NotchCustomizationStoreTests`, `AutoWidthTests` |
+
+## Not Changed
+
+- Theme, font, visibility toggles, sound — remain global.
+- `NotchCustomizationSettingsView` — geometry is adjusted in Live Edit only.
+- Opened-state panel heights — content-dependent, not user-adjustable.


### PR DESCRIPTION
## Summary / 概要

**EN:** Add per-screen notch height customization. External 4K displays have no hardware notch, so the closed-state notch height was previously hardcoded to 38pt. Users can now adjust it via Live Edit mode. Width, offset, and height are all stored per-screen.

**中文：** 新增按显示器独立配置刘海高度功能。外接 4K 显示器没有硬件刘海，之前 closed 状态高度固定为 38pt，现在用户可以在 Live Edit 模式中自由调节。宽度、偏移、高度三个几何属性均按显示器独立存储。

## Changes / 变更内容

- **New `ScreenGeometry` struct / 新增 `ScreenGeometry` 结构体** — holds `maxWidth`, `horizontalOffset`, `notchHeight` per-screen / 按显示器存储三个几何属性
- **Per-screen storage / 按显示器存储** — `NotchCustomization.screenGeometries: [String: ScreenGeometry]` dictionary keyed by stable display identifier / 以稳定的显示器标识符为 key 的字典
- **Stable screen ID / 稳定屏幕标识** — uses `CGDisplayVendorNumber + ModelNumber + SerialNumber` composite key that survives reboots / 使用 vendor+model+serial 复合 key，跨重启稳定
- **Height controls in Live Edit / Live Edit 高度控制** — ▲▼ arrow buttons below the notch (disabled on hardware notch screens) / 刘海下方的 ▲▼ 箭头按钮（硬件刘海屏自动禁用）
- **Readout update / 数值显示更新** — shows `W xxxpt  H xxpt  X +xxpt` / 显示宽度、高度、偏移三个值
- **Legacy migration / 向后兼容迁移** — auto-migrates old global `maxWidth`/`horizontalOffset` to `defaultGeometry` / 自动将旧版全局配置迁移到 defaultGeometry
- **Full test coverage / 完整测试覆盖** — ScreenGeometry defaults, Codable roundtrip, legacy migration, per-screen isolation, store persistence, height clamping

## Files changed / 修改文件

| File | Change |
|------|--------|
| `NotchCustomization.swift` | Add `ScreenGeometry`, per-screen dict, legacy migration decoder |
| `Ext+NSScreen.swift` | Add `persistentID` (EDID composite key) |
| `NotchHardwareDetector.swift` | Add `clampedHeight()`, min/max constants |
| `NotchCustomizationStore.swift` | Add `updateGeometry(for:)` |
| `NotchWindowController.swift` | Store `screenID`, read per-screen geometry |
| `NotchViewModel.swift` | Pass `screenID`, per-screen offset reads |
| `NotchView.swift` | Per-screen `closedNotchSize`, `expansionWidth`, `clampedHorizontalOffset` |
| `NotchLiveEditOverlay.swift` | ▲▼ height buttons, all geometry ops per-screen |
| Tests (3 files) | New + updated tests for all model/store changes |

## Test plan / 测试计划

- [ ] Enter Live Edit on external 4K display, adjust height / 外接 4K 显示器进入 Live Edit 调节高度
- [ ] Confirm height buttons disabled on built-in notch screen / 内置刘海屏确认高度按钮禁用
- [ ] Switch between displays, confirm independent configs / 多显示器切换确认配置独立
- [ ] Reboot, confirm external display config persists / 重启后确认外接显示器配置保留
- [ ] Cancel edit confirms rollback, save confirms persistence / 取消编辑确认回滚，保存确认持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)