### PR TITLE
fix: auto-cleanup ended sessions after 1 hour

### DIFF
--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -61,6 +61,8 @@ struct SessionState: Equatable, Identifiable, Sendable {
 
     var lastActivity: Date
     var createdAt: Date
+    /// When the session was marked as ended (for auto-cleanup after timeout)
+    var endedAt: Date?
 
     // MARK: - Identifiable
 

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -182,6 +182,7 @@ actor SessionStore {
 
         if event.status == "ended" {
             session.phase = .ended
+            session.endedAt = Date()
             sessions[sessionId] = session
             cancelPendingSync(sessionId: sessionId)
             publishState()
@@ -958,24 +959,38 @@ actor SessionStore {
         zombieScanTask = nil
     }
 
-    /// Check all non-ended sessions for dead processes
+    /// Check all non-ended sessions for dead processes, and auto-clean stale ended sessions
     func scanForZombies() {
         var changed = false
         var zombieSessionIds: [String] = []
+
+        // 1. Detect zombie sessions (dead processes)
         for (sessionId, session) in sessions {
             guard session.phase != .ended else { continue }
             guard let pid = session.pid else { continue }
             if !livenessChecker.isAlive(pid: pid) {
                 Self.logger.info("Zombie detected: session \(sessionId.prefix(8), privacy: .public) PID \(pid) is dead")
                 sessions[sessionId]?.phase = .ended
+                sessions[sessionId]?.endedAt = Date()
                 cancelPendingSync(sessionId: sessionId)
                 zombieSessionIds.append(sessionId)
                 changed = true
             }
         }
+
+        // 2. Auto-clean ended sessions older than 1 hour
+        let staleThreshold = Date().addingTimeInterval(-3600) // 1 hour
+        let staleIds = sessions.filter { _, session in
+            session.phase == .ended && (session.endedAt ?? session.lastActivity) < staleThreshold
+        }.map(\.key)
+        for id in staleIds {
+            Self.logger.info("Auto-cleaning stale ended session: \(id.prefix(8), privacy: .public)")
+            sessions.removeValue(forKey: id)
+            cancelPendingSync(sessionId: id)
+            changed = true
+        }
+
         if changed {
-            // Clean up HookSocketServer pending permissions and interrupt watchers
-            // (mirrors the cleanup that normal Stop/ended hook events perform)
             for sessionId in zombieSessionIds {
                 Task { @MainActor in
                     HookSocketServer.shared.cancelPendingPermissions(sessionId: sessionId)


### PR DESCRIPTION
## Summary
- Ended sessions were staying in the session list indefinitely (16+ stale sessions cluttering UI)
- Now zombie scan auto-removes sessions that have been ended for over 1 hour
- Sessions ended within the last hour remain visible so users can check recent status

## Changes
- `SessionState.swift`: Add `endedAt: Date?` field
- `SessionStore.swift`: Set `endedAt` on session end + auto-clean stale sessions in `scanForZombies()`

## Test plan
- [ ] End a Claude Code session, confirm it shows in list with "已结束" badge
- [ ] Wait 1 hour (or manually set `endedAt` to past), confirm session auto-removed on next scan
- [ ] Confirm active sessions are unaffected
- [ ] Confirm sessions without `endedAt` (legacy) use `lastActivity` as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)