### PR TITLE
fix: UI polish + notch click-through on repositioned displays

### DIFF
--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -58,6 +58,7 @@ struct ClaudeInstancesView: View {
                         flatList
                     }
                 }
+                .padding(.bottom, 50)
 
                 // Bottom right: buddy + usage stats
                 // Hidden when buddy card open or when expanded with many sessions
@@ -87,6 +88,7 @@ struct ClaudeInstancesView: View {
                         }
                     }
                     .padding(.trailing, 4)
+                    .padding(.bottom, 12)
                     .padding(.bottom, 2)
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -57,7 +57,7 @@ struct NotchMenuView: View {
             // All toggles / pickers / accessibility now live in the floating
             // SystemSettingsWindow opened from the Settings row below.
             ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 4) {
+                VStack(spacing: 8) {
                     // Yesterday's activity report. Renders nothing on quiet
                     // days so the menu stays compact when you didn't work.
                     DailyReportCard(viewModel: viewModel)
@@ -66,6 +66,7 @@ struct NotchMenuView: View {
                     SystemSettingsRow()
                 }
                 .padding(.horizontal, 4)
+                .padding(.top, 8)
                 .padding(.bottom, 8)
             }
         }

--- a/ClaudeIsland/UI/Views/PairPhoneView.swift
+++ b/ClaudeIsland/UI/Views/PairPhoneView.swift
@@ -45,6 +45,7 @@ struct PairPhoneRow: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+            .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: 8)
                     .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
@@ -194,6 +195,7 @@ private struct QRPairingContentView: View {
             RoundedRectangle(cornerRadius: 20)
                 .strokeBorder(Self.cardText.opacity(0.1), lineWidth: 0.5)
         )
+        .clipShape(RoundedRectangle(cornerRadius: 20))
         .onAppear {
             generateQRCode()
             Task { await refreshLinkedDevices() }
@@ -268,7 +270,7 @@ private struct QRPairingContentView: View {
 
         // Linked devices section
         if !linkedDevices.isEmpty {
-            VStack(spacing: 0) {
+            VStack(spacing: 4) {
                 HStack {
                     Text("Linked Devices")
                         .font(.system(size: 10, weight: .semibold))

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -47,6 +47,7 @@ struct SystemSettingsRow: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+            .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: 8)
                     .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)

--- a/ClaudeIsland/UI/Window/NotchWindow.swift
+++ b/ClaudeIsland/UI/Window/NotchWindow.swift
@@ -46,7 +46,8 @@ class NotchPanel: NSPanel {
             .ignoresCycle
         ]
 
-        // Above the menu bar
+        // Above the menu bar. Dynamic elevation happens in
+        // NotchWindowController when the notch opens/closes.
         level = .mainMenu + 3
 
         // Enable tooltips even when app is inactive (needed for panel windows)

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -86,6 +86,8 @@ class NotchWindowController: NSWindowController {
                     // Accept mouse events when opened so buttons work
                     notchWindow?.ignoresMouseEvents = false
                     notchWindow?.acceptsMouseMovedEvents = true
+                    // Elevate above menu bar icons so clicks land on the notch
+                    notchWindow?.level = .popUpMenu
                     // Only steal focus on user-initiated opens (click)
                     // Hover/notification opens should not interrupt typing in other apps
                     if viewModel?.shouldActivateOnOpen == true {
@@ -97,6 +99,9 @@ class NotchWindowController: NSWindowController {
                 case .closed, .popping:
                     // Ignore mouse events when closed so clicks pass through
                     notchWindow?.ignoresMouseEvents = true
+                    // Lower back to normal level so transparent areas
+                    // don't block clicks on menu bar icons
+                    notchWindow?.level = .mainMenu + 3
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary

### UI 修复
- 配对弹窗四角圆角裁切（之前溢出显示直角）
- Linked Devices 列表间距 0→4pt（之前挤在一起）
- Pair iPhone / 设置 按钮整行可点击和 hover（之前只有文字区域响应）
- 用量统计区域增加底部间距，避免和会话列表重叠
- 菜单页面项目间距 4→8pt，顶部增加 padding

### Bug 修复
- 刘海移到非默认位置时（外接显示器），点击展开的刘海内容会穿透触发后面的菜单栏图标
- 修复方案：展开时动态提升窗口层级到 `.popUpMenu`，关闭时降回 `.mainMenu+3`

## Files changed (6 files, +15/-3)
| File | Change |
|------|--------|
| `PairPhoneView.swift` | clipShape 圆角 + linked devices 间距 + contentShape |
| `SystemSettingsView.swift` | contentShape 整行可点击 |
| `ClaudeInstancesView.swift` | 用量区域底部间距 |
| `NotchMenuView.swift` | 菜单间距优化 |
| `NotchWindow.swift` | 窗口层级注释更新 |
| `NotchWindowController.swift` | 动态窗口层级切换 |

## Test plan
- [ ] 配对弹窗四角无直角溢出
- [ ] Linked Devices 列表有间距
- [ ] Pair iPhone / 设置行空白区域可点击和 hover
- [ ] 外接显示器移动刘海位置后，展开点击不穿透
- [ ] 关闭态菜单栏图标正常可点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)