### PR TITLE
fix: cmux probe hang + UI polish + quit button

### DIFF
--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -108,16 +108,16 @@ enum L10n {
     static var anthropicApiProxyDescription: String {
         tr(
             """
-            Applies to: the rate-limit bar (api.anthropic.com) and every subprocess CodeIsland spawns — including the Stats plugin's claude CLI and any future plugin's shell-outs. We set HTTPS_PROXY / HTTP_PROXY / ALL_PROXY on CodeIsland's own process once at startup, so children inherit it automatically. No launchctl pollution, no per-plugin opt-in.
+            Applies to: the rate-limit bar (api.anthropic.com) and every subprocess MioIsland spawns — including the Stats plugin's claude CLI and any future plugin's shell-outs. HTTPS_PROXY / HTTP_PROXY / ALL_PROXY are set once at startup, all children inherit automatically.
 
-            Does NOT apply to: CodeLight sync (our own server, stays direct), or third-party plugins that use their own URLSession to reach external APIs — those honor system proxy settings instead.
+            Does NOT apply to: CodeLight sync (always direct) or third-party plugin URLSession calls (those use system proxy).
 
             Leave empty for direct connection.
             """,
             """
-            作用于:刘海额度条(api.anthropic.com)和 CodeIsland 启动的所有子进程 —— 包括 Stats 插件的 claude CLI、未来任何插件的 shell-out。我们在启动时给 CodeIsland 自身进程 `setenv` 一次 HTTPS_PROXY / HTTP_PROXY / ALL_PROXY,所有子进程自动继承。不污染全局,不需要每个插件单独适配。
+            作用于：刘海额度条 (api.anthropic.com) 和 MioIsland 启动的所有子进程，包括 Stats 插件的 claude CLI。启动时设置一次 HTTPS_PROXY / HTTP_PROXY / ALL_PROXY，子进程自动继承。
 
-            不作用于:CodeLight 同步(我们自己的服务器,始终直连);以及第三方插件自己用 URLSession 调用外部 API 的场景(那种走系统代理设置)。
+            不作用于：CodeLight 同步（始终直连）、第三方插件的 URLSession 调用（走系统代理）。
 
             留空即直连。
             """
@@ -218,6 +218,7 @@ enum L10n {
     static var starOnGitHub: String { tr("Star on GitHub", "GitHub 点星") }
     static var wechatLabel: String { tr("WeChat", "微信") }
     static var maintainedTagline: String { tr("Actively maintained · Your star keeps us going!", "持续更新中 · Star 是我们最大的动力！") }
+    static var quitApp: String { tr("Quit Mio Island", "退出 Mio Island") }
 
     // MARK: - Plugin marketplace
     static var pluginMarketplaceTitle: String { tr("Plugin Marketplace", "插件市场") }

--- a/ClaudeIsland/Services/Sync/TerminalWriter.swift
+++ b/ClaudeIsland/Services/Sync/TerminalWriter.swift
@@ -182,9 +182,9 @@ final class TerminalWriter {
             }
             defer { AEDisposeDesc(&targetAddr) }
 
-            // Now the question is correctly: "Can Code Island automate this terminal?"
+            // Check: "Can this app automate the target terminal?"
             let status = AEDeterminePermissionToAutomateTarget(
-                &requestorAddr,
+                &targetAddr,
                 AEEventClass(typeWildCard),
                 AEEventID(typeWildCard),
                 false
@@ -911,13 +911,9 @@ final class TerminalWriter {
                   let sessionId = json["sessionId"] as? String,
                   Self.isUuidLike(sessionId) else { continue }
 
-            // Verify the process is still alive
-            let (out, ok) = await runShellWithTimeout(
-                "/bin/ps", ["-p", "\(pid)", "-o", "pid="], timeout: 1.0
-            )
-            guard ok,
-                  let line = out?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  line == "\(pid)" else { continue }
+            // Verify the process is still alive using kill(0) signal check.
+            // Faster and more reliable than spawning /bin/ps subprocess.
+            guard kill(Int32(pid), 0) == 0 else { continue }
 
             // Prefer cwd from the JSON; fall back to lsof if absent
             let cwd: String

--- a/ClaudeIsland/UI/Views/NativePluginStoreView.swift
+++ b/ClaudeIsland/UI/Views/NativePluginStoreView.swift
@@ -160,7 +160,7 @@ struct NativePluginStoreView: View {
                 .foregroundColor(.white.opacity(0.45))
 
             HStack(spacing: 8) {
-                TextField("https://api.miomio.chat/api/i/...", text: $installURLText)
+                TextField("", text: $installURLText, prompt: Text("https://api.miomio.chat/api/i/...").foregroundColor(.white.opacity(0.3)))
                     .textFieldStyle(.plain)
                     .font(.system(size: 12, design: .monospaced))
                     .foregroundColor(.white.opacity(0.9))

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -456,7 +456,7 @@ private struct AnthropicProxyRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            TextField(L10n.anthropicApiProxyPlaceholder, text: $proxyURL)
+            TextField("", text: $proxyURL, prompt: Text(L10n.anthropicApiProxyPlaceholder).foregroundColor(.white.opacity(0.3)))
                 .textFieldStyle(.plain)
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.white.opacity(0.95))
@@ -472,8 +472,9 @@ private struct AnthropicProxyRow: View {
                 )
 
             Text(L10n.anthropicApiProxyDescription)
-                .font(.system(size: 10))
-                .foregroundColor(.white.opacity(0.5))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(Color(white: 0.75))
+                .lineSpacing(4)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -746,6 +747,30 @@ private struct AboutTab: View {
                 .foregroundColor(Theme.detailText.opacity(0.5))
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.top, 4)
+
+            Button {
+                NSApplication.shared.terminate(nil)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "power")
+                        .font(.system(size: 11))
+                    Text(L10n.quitApp)
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .foregroundColor(.red.opacity(0.8))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.red.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Color.red.opacity(0.15), lineWidth: 0.5)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 4)
         }
     }
 


### PR DESCRIPTION
## Bug 修复

### #60 probeAutomationPermission 卡死（严重）
- `AEDeterminePermissionToAutomateTarget` 的第一个参数传了 `&requestorAddr`（自己的地址），应该传 `&targetAddr`（目标终端的地址）
- 传错参数导致 AE 权限检查对着自己查权限，返回错误状态，整个设置面板卡死
- 修复：`&requestorAddr` → `&targetAddr`

### #59 discoverClaudeSessionsFromConfig 检测失败
- 用 `runShellWithTimeout("/bin/ps")` 启动子进程验证 pid 存活，在某些签名环境下子进程执行失败，导致 Claude 会话数始终为 0
- 修复：改用 `kill(pid, 0)` 内核信号检查，无需子进程，所有环境下都能正常工作

## UI 优化

- **退出按钮**：设置 → 关于页面底部新增红色"退出 Mio Island"按钮
- **代理说明文字**：提高可读性（medium 字重、灰白色、加大行距），CodeIsland → MioIsland
- **输入框 placeholder**：代理 URL 和插件安装 URL 的格式提示文字从黑色改为淡灰色

## Files changed (4 files, +39/-17)
| File | Change |
|------|--------|
| `TerminalWriter.swift` | AE 参数修复 + kill(0) 替代 ps |
| `SystemSettingsView.swift` | 退出按钮 + 代理文字样式 + placeholder 颜色 |
| `NativePluginStoreView.swift` | 插件 URL placeholder 颜色 |
| `Localization.swift` | 退出按钮文案 + 代理说明文案更新 |

## Test plan
- [ ] 设置 → cmux 连接 tab：不卡死，cmux 命令行/会话数/自动化权限正确显示
- [ ] 刷新和测试发送按钮正常工作
- [ ] 设置 → 关于：退出按钮正常退出 app
- [ ] 代理 URL 输入框 placeholder 显示为淡灰色
- [ ] 插件安装 URL 输入框 placeholder 显示为淡灰色

🤖 Generated with [Claude Code](https://claude.com/claude-code)